### PR TITLE
Feature/sim 1103/rewrite obs metadata

### DIFF
--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -181,10 +181,10 @@ class ObservationMetaData(object):
             return
 
         if self._boundLength is None:
-            raise RuntimeError('ObservationMetadata cannot assign a bounds; it has no boundLength')
+            return
 
         if self._unrefractedRA is None or self._unrefractedDec is None:
-            raise RuntimeError('ObservationMetadata cannot assign a bounds; it has no unrefractedRA/Dec')
+            return
 
         self._bounds = SpatialBounds.getSpatialBounds(self._boundType, self._unrefractedRA, self._unrefractedDec,
                                                      self._boundLength)

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -94,8 +94,8 @@ class ObservationMetaData(object):
                     for ll in boundLength:
                         self._boundLength.append(numpy.radians(ll))
                 except:
-                    raise RuntimeError("You seem to have passed something that is neither a float nor " +
-                                       "list-like as boundLength to ObservationMetaData")
+                    raise RuntimeError('You seem to have passed something that is neither a float nor ' +
+                                       'list-like as boundLength to ObservationMetaData')
         else:
             self._boundLength = None
 
@@ -104,43 +104,13 @@ class ObservationMetaData(object):
         else:
             self._phoSimMetadata = None
 
+        self.assignM5(m5)
+
         #this should be done after phoSimMetadata is assigned, just in case
         #assignPhoSimMetadata overwrites unrefractedRA/Dec
         if self._bounds is None:
             self.buildBounds()
 
-        if m5 is None:
-            self._m5 = None
-        else:
-            bandpassIsList = False
-            m5IsList = False
-            if hasattr(self.bandpass, '__iter__'):
-                bandpassIsList = True
-
-            if hasattr(m5, '__iter__'):
-                m5IsList = True
-
-            if bandpassIsList and not m5IsList:
-                raise RuntimeError('You passed a list of bandpass names' + \
-                                   'but did not pass a list of m5s to ObservationMetaData')
-
-            if m5IsList and not bandpassIsList:
-                raise RuntimeError('You passed a list of m5s ' + \
-                                    'but did not pass a list of bandpass names to ObservationMetaData')
-
-
-            if m5IsList:
-                if len(m5) != len(self.bandpass):
-                    raise RuntimeError('The list of m5s you passed to ObservationMetaData ' + \
-                                       'has a different length than the list of bandpass names you passed')
-
-            #now build the m5 dict
-            if bandpassIsList:
-                self._m5 = {}
-                for b, m in zip(self._bandpass, m5):
-                    self._m5[b] = m
-            else:
-                self._m5 = {self._bandpass:m5}
 
     @property
     def summary(self):
@@ -162,15 +132,59 @@ class ObservationMetaData(object):
 
         return mydict
 
+    def assignM5(self, m5):
+
+        if m5 is None:
+            self._m5 = None
+        else:
+            bandpassIsList = False
+            m5IsList = False
+
+            if self._bandpass is None:
+                raise RuntimeError('You cannot set m5 if you have not set bandpass in ObservationMetaData')
+
+            if hasattr(self._bandpass, '__iter__'):
+                bandpassIsList = True
+
+            if hasattr(m5, '__iter__'):
+                m5IsList = True
+
+            if bandpassIsList and not m5IsList:
+                raise RuntimeError('You passed a list of bandpass names' + \
+                                   'but did not pass a list of m5s to ObservationMetaData')
+
+            if m5IsList and not bandpassIsList:
+                raise RuntimeError('You passed a list of m5s ' + \
+                                    'but did not pass a list of bandpass names to ObservationMetaData')
+
+
+            if m5IsList:
+                if len(m5) != len(self._bandpass):
+                    raise RuntimeError('The list of m5s you passed to ObservationMetaData ' + \
+                                       'has a different length than the list of bandpass names you passed')
+
+            #now build the m5 dict
+            if bandpassIsList:
+                if len(m5) != len(self._bandpass):
+                    raise RuntimeError('In ObservationMetaData you tried to assign bandpass ' +
+                                       'and m5 with lists of different length')
+
+                self._m5 = {}
+                for b, m in zip(self._bandpass, m5):
+                    self._m5[b] = m
+            else:
+                self._m5 = {self._bandpass:m5}
+
+
     def buildBounds(self):
         if self._boundType is None:
             return
 
         if self._boundLength is None:
-            raise RuntimeError("ObservationMetadata cannot assign a bounds; it has no boundLength")
+            raise RuntimeError('ObservationMetadata cannot assign a bounds; it has no boundLength')
 
         if self._unrefractedRA is None or self._unrefractedDec is None:
-            raise RuntimeError("ObservationMetadata cannot assign a bounds; it has no unrefractedRA/Dec")
+            raise RuntimeError('ObservationMetadata cannot assign a bounds; it has no unrefractedRA/Dec')
 
         self._bounds = SpatialBounds.getSpatialBounds(self._boundType, self._unrefractedRA, self._unrefractedDec,
                                                      self._boundLength)
@@ -185,35 +199,35 @@ class ObservationMetaData(object):
         #overwrite member variables with values from the phoSimMetadata
         if self._phoSimMetadata is not None and 'Opsim_expmjd' in self._phoSimMetadata:
             if self._mjd is not None:
-                raise RuntimeError("WARNING in ObservationMetaData trying to overwrite mjd with phoSimMetadata")
+                raise RuntimeError('WARNING in ObservationMetaData trying to overwrite mjd with phoSimMetadata')
 
             self._mjd = self._phoSimMetadata['Opsim_expmjd'][0]
 
         if self._phoSimMetadata is not None and 'Unrefracted_RA' in self._phoSimMetadata:
             if self._unrefractedRA is not None:
-                raise RuntimeError("WARNING in ObservationMetaData trying to overwrite unrefractedRA " +
-                                   "with phoSimMetadata")
+                raise RuntimeError('WARNING in ObservationMetaData trying to overwrite unrefractedRA ' +
+                                   'with phoSimMetadata')
 
             self._unrefractedRA = self._phoSimMetadata['Unrefracted_RA'][0]
 
         if self._phoSimMetadata is not None and 'Opsim_rotskypos' in self._phoSimMetadata:
             if self._rotSkyPos is not None:
-                raise RuntimeError("WARNING in ObservationMetaData trying to overwrite rotSkyPos " +
-                                   "with phoSimMetadata")
+                raise RuntimeError('WARNING in ObservationMetaData trying to overwrite rotSkyPos ' +
+                                   'with phoSimMetadata')
 
             self._rotSkyPos = self.phoSimMetadata['Opsim_rotskypos'][0]
 
         if self._phoSimMetadata is not None and 'Unrefracted_Dec' in self._phoSimMetadata:
             if self._unrefractedDec is not None:
-                raise RuntimeError("WARNING in ObservationMetaData trying to overwrite unrefractedDec " +
-                                   "with phoSimMetadata")
+                raise RuntimeError('WARNING in ObservationMetaData trying to overwrite unrefractedDec ' +
+                                   'with phoSimMetadata')
 
             self._unrefractedDec = self._phoSimMetadata['Unrefracted_Dec'][0]
 
         if self._phoSimMetadata is not None and 'Opsim_filter' in self._phoSimMetadata:
             if self._bandpass is not None:
-                raise RuntimeError("WARNING in ObservationMetaData trying to overwrite bandpass " +
-                                   "with phoSimMetadata")
+                raise RuntimeError('WARNING in ObservationMetaData trying to overwrite bandpass ' +
+                                   'with phoSimMetadata')
 
             self._bandpass = self._phoSimMetadata['Opsim_filter'][0]
 
@@ -223,17 +237,49 @@ class ObservationMetaData(object):
     def unrefractedRA(self):
         return self._unrefractedRA
 
+    @unrefractedRA.setter
+    def unrefractedRA(self, value):
+        if self._phoSimMetadata is not None:
+            if 'Unrefracted_RA' in self._phoSimMetadata:
+                raise RuntimeError('WARNING overwriting Unrefracted_RA ' +
+                                   'which was set by phoSimMetaData which was set ' +
+                                   'by phoSimMetadata')
+
+        self._unrefractedRA = numpy.degrees(value)
+        self.buildBounds()
+
     @property
     def unrefractedDec(self):
         return self._unrefractedDec
+
+    @unrefractedDec.setter
+    def unrefractedDec(self, value):
+        if self._phoSimMetadata is not None:
+            if 'Unrefracted_Dec' in self._phoSimMetadata:
+                raise RuntimeError('WARNING overwriting Unrefracted_Dec ' +
+                                   'which was set by phoSimMetaData which was set ' +
+                                   'by phoSimMetadata')
+
+        self._unrefractedDec = numpy.radians(value)
+        self.buildBounds()
 
     @property
     def boundLength(self):
         return self._boundLength
 
+    @boundLength.setter
+    def boundLength(self, value):
+        self._boundLength = numpy.radians(value)
+        self.buildBounds()
+
     @property
     def boundType(self):
         return self._boundType
+
+    @boundType.setter
+    def boundType(self, value):
+        self._boundType = value
+        self.buildBounds()
 
     @property
     def bounds(self):
@@ -246,21 +292,46 @@ class ObservationMetaData(object):
         else:
             return 0.0
 
+    @rotSkyPos.setter
+    def rotSkyPos(self,value):
+        if self._phoSimMetadata is not None:
+            if 'Opsim_rotskypos' in self._phoSimMetadata:
+                raise RuntimeError('WARNING overwriting rotSkyPos ' +
+                                   'which was set by phoSimMetaData which was set ' +
+                                   'by phoSimMetadata')
+
+        self._rotSkyPos = numpy.radians(value)
+
+
     @property
     def m5(self):
         return self._m5
 
     @m5.setter
     def m5(self, value):
-        self._m5 = value
+        self.assignM5(value)
 
     @property
     def site(self):
         return self._site
 
+    @site.setter
+    def site(self, value):
+        self._site = value
+
     @property
     def mjd(self):
         return self._mjd
+
+    @mjd.setter
+    def mjd(self, value):
+        if self._phoSimMetadata is not None:
+            if 'Opsim_expmjd' in self._phoSimMetadata:
+                raise RuntimeError('WARNING overwriting mjd ' +
+                                   'which was set by phoSimMetaData which was set ' +
+                                   'by phoSimMetadata')
+
+        self._mjd = value
 
     @property
     def bandpass(self):
@@ -269,10 +340,44 @@ class ObservationMetaData(object):
         else:
             return 'r'
 
+    def setBandpassAndM5(self, bandpass, m5):
+        if self._phoSimMetadata is not None:
+            if 'Opsim_filter' in self._phoSimMetadata:
+                raise RuntimeError('WARNING overwriting bandpass ' +
+                                   'which was set by phoSimMetaData which was set ' +
+                                   'by phoSimMetadata')
+
+        self._bandpass = bandpass
+        self.assignM5(m5)
+
     @property
     def skyBrightness(self):
         return self._skyBrightness
 
+    @skyBrightness.setter
+    def skyBrightness(self, value):
+        self._skyBrightness = value
+
     @property
     def phoSimMetadata(self):
         return self._phoSimMetadata
+
+    @phoSimMetadata.setter
+    def phoSimMetadata(self, value):
+        if 'Unrefracted_RA' in value:
+            self._unrefractedRA = None
+
+        if 'Unrefracted_Dec' in value:
+            self._unrefractedDec = None
+
+        if 'Opsim_rotskypos' in value:
+            self._rotSkyPos = None
+
+        if 'Opsim_expmjd' in value:
+            self._mjd = None
+
+        if 'Opsim_filter' in value:
+            self._bandpass = None
+            self._m5 = None
+
+        self.assignPhoSimMetaData(value)

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -100,7 +100,7 @@ class ObservationMetaData(object):
         #this should be done after phoSimMetadata is assigned, just in case
         #assignPhoSimMetadata overwrites unrefractedRA/Dec
         if self._bounds is None:
-            self.buildBounds()
+            self._buildBounds()
 
 
     @property
@@ -167,7 +167,7 @@ class ObservationMetaData(object):
                 self._m5 = {self._bandpass:m5}
 
 
-    def buildBounds(self):
+    def _buildBounds(self):
         if self._boundType is None:
             return
 
@@ -222,7 +222,7 @@ class ObservationMetaData(object):
 
             self._bandpass = self._phoSimMetadata['Opsim_filter'][0]
 
-        self.buildBounds()
+        self._buildBounds()
 
     @property
     def unrefractedRA(self):
@@ -239,7 +239,7 @@ class ObservationMetaData(object):
                                    'which was set by phoSimMetaData')
 
         self._unrefractedRA = numpy.radians(value)
-        self.buildBounds()
+        self._buildBounds()
 
     @property
     def unrefractedDec(self):
@@ -256,7 +256,7 @@ class ObservationMetaData(object):
                                    'which was set by phoSimMetaData')
 
         self._unrefractedDec = numpy.radians(value)
-        self.buildBounds()
+        self._buildBounds()
 
     @property
     def boundLength(self):
@@ -265,7 +265,7 @@ class ObservationMetaData(object):
     @boundLength.setter
     def boundLength(self, value):
         self._boundLength = numpy.radians(value)
-        self.buildBounds()
+        self._buildBounds()
 
     @property
     def boundType(self):
@@ -274,7 +274,7 @@ class ObservationMetaData(object):
     @boundType.setter
     def boundType(self, value):
         self._boundType = value
-        self.buildBounds()
+        self._buildBounds()
 
     @property
     def bounds(self):

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -86,16 +86,7 @@ class ObservationMetaData(object):
             self._unrefractedDec = None
 
         if boundLength is not None:
-            if isinstance(boundLength, float):
-                self._boundLength = numpy.radians(boundLength)
-            else:
-                try:
-                    self._boundLength = []
-                    for ll in boundLength:
-                        self._boundLength.append(numpy.radians(ll))
-                except:
-                    raise RuntimeError('You seem to have passed something that is neither a float nor ' +
-                                       'list-like as boundLength to ObservationMetaData')
+            self._boundLength = numpy.radians(boundLength)
         else:
             self._boundLength = None
 
@@ -247,7 +238,7 @@ class ObservationMetaData(object):
                 raise RuntimeError('WARNING overwriting Unrefracted_RA ' +
                                    'which was set by phoSimMetaData')
 
-        self._unrefractedRA = numpy.degrees(value)
+        self._unrefractedRA = numpy.radians(value)
         self.buildBounds()
 
     @property
@@ -269,7 +260,7 @@ class ObservationMetaData(object):
 
     @property
     def boundLength(self):
-        return self._boundLength
+        return numpy.degrees(self._boundLength)
 
     @boundLength.setter
     def boundLength(self, value):
@@ -292,7 +283,7 @@ class ObservationMetaData(object):
     @property
     def rotSkyPos(self):
         if self._rotSkyPos is not None:
-            return self._rotSkyPos
+            return numpy.degrees(self._rotSkyPos)
         else:
             return 0.0
 

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -124,6 +124,19 @@ class ObservationMetaData(object):
         return mydict
 
     def _assignM5(self, m5):
+        """
+        This method sets up the dict self._m5.  It reads in a list of m5 values
+        and associates them with the list of bandpass names in self._bandpass.
+
+        Note: this method assumes that self._bandpass has already been set.
+        It will raise an exception of self._bandpass is None.
+
+        @param [in] m5 is a list of m5 values corresponding to the bandpasses
+        stored in self._bandpass
+
+        This method does not return anything.  It just sets the member variable
+        self._m5.
+        """
 
         if m5 is None:
             self._m5 = None
@@ -168,6 +181,13 @@ class ObservationMetaData(object):
 
 
     def _buildBounds(self):
+        """
+        Set up the member variable self._bounds.
+
+        If self._boundType, self._boundLength, self._unrefractedRA, or
+        self._unrefractedDec are None, nothing will happen.
+        """
+
         if self._boundType is None:
             return
 
@@ -182,7 +202,12 @@ class ObservationMetaData(object):
 
     def _assignPhoSimMetaData(self, metaData):
         """
-        Assign the dict metaData to be the associated metadata dict of this object
+        Assign the dict metaData to be the associated phoSimMetaData dict of this object.
+
+        In doing so, this method will copy unrefractedRA, unrefractedDec, rotSkyPos,
+        MJD, and bandpass from the phoSimMetaData (if present) to the corresponding
+        member variables.  If by doing so you try to overwrite a parameter that you
+        have already set by hand, this method will raise an exception.
         """
 
         self._phoSimMetaData = metaData
@@ -226,6 +251,9 @@ class ObservationMetaData(object):
 
     @property
     def unrefractedRA(self):
+        """
+        The above-the-atmospher RA of the telescope pointing in degrees.
+        """
         if self._unrefractedRA is not None:
             return numpy.degrees(self._unrefractedRA)
         else:
@@ -243,6 +271,9 @@ class ObservationMetaData(object):
 
     @property
     def unrefractedDec(self):
+        """
+        The above-the-atmosphere Dec of the telescope pointing in degrees.
+        """
         if self._unrefractedDec is not None:
             return numpy.degrees(self._unrefractedDec)
         else:
@@ -260,6 +291,17 @@ class ObservationMetaData(object):
 
     @property
     def boundLength(self):
+        """
+        Either a list or a float indicating the size of the field
+        of view associated with this ObservationMetaData.
+
+        See the documentation in the SpatialBounds class for more
+        details (specifically, the 'length' paramter).
+
+        In degrees (Yes: the documentation in SpatialBounds says that
+        the length should be in degrees.  The present class converts
+        from degrees to radians before passing to SpatialBounds.
+        """
         return numpy.degrees(self._boundLength)
 
     @boundLength.setter
@@ -269,6 +311,10 @@ class ObservationMetaData(object):
 
     @property
     def boundType(self):
+        """
+        Tag indicating what sub-class of SpatialBounds should
+        be instantiated for this ObservationMetaData.
+        """
         return self._boundType
 
     @boundType.setter
@@ -278,10 +324,19 @@ class ObservationMetaData(object):
 
     @property
     def bounds(self):
+        """
+        Instantiation of a sub-class of SpatialBounds.  This
+        is what actually construct the WHERE clause of the SQL
+        query associated with this ObservationMetaData.
+        """
         return self._bounds
 
     @property
     def rotSkyPos(self):
+        """
+        The rotation of the telescope with respect to the sky in degrees.
+        It is a parameter you should get from OpSim.
+        """
         if self._rotSkyPos is not None:
             return numpy.degrees(self._rotSkyPos)
         else:
@@ -300,6 +355,11 @@ class ObservationMetaData(object):
 
     @property
     def m5(self):
+        """
+        A dict of m5 (the 5-sigma limiting magnitude) values
+        associated with the bandpasses represented by this
+        ObservationMetaData.
+        """
         return self._m5
 
     @m5.setter
@@ -308,6 +368,10 @@ class ObservationMetaData(object):
 
     @property
     def site(self):
+        """
+        An instantiation of the Site class containing information about
+        the telescope site.
+        """
         return self._site
 
     @site.setter
@@ -316,6 +380,9 @@ class ObservationMetaData(object):
 
     @property
     def mjd(self):
+        """
+        The MJD of the observation associated with this ObservationMetaData.
+        """
         return self._mjd
 
     @mjd.setter
@@ -330,12 +397,29 @@ class ObservationMetaData(object):
 
     @property
     def bandpass(self):
+        """
+        The bandpass associated with this ObservationMetaData.
+        Can be a list.
+        """
         if self._bandpass is not None:
             return self._bandpass
         else:
             return 'r'
 
     def setBandpassAndM5(self, bandpassName=None, m5=None):
+        """
+        Set the bandpasses and associated 5-sigma limiting magnitudes
+        for this ObservationMetaData.
+
+        @param [in] bandpassName is either a char or a list of chars denoting
+        the name of the bandpass associated with this ObservationMetaData.
+
+        @param [in] m5 is the 5-sigma-limiting magnitude(s) associated
+        with bandpassName
+
+        Nothing is returned.  This method just sets member variables of
+        this ObservationMetaData.
+        """
         if self._phoSimMetaData is not None:
             if 'Opsim_filter' in self._phoSimMetaData:
                 raise RuntimeError('WARNING overwriting bandpass ' +
@@ -347,6 +431,10 @@ class ObservationMetaData(object):
 
     @property
     def skyBrightness(self):
+        """
+        The sky brightness in mags per square arcsecond associated
+        with this ObservationMetaData.
+        """
         return self._skyBrightness
 
     @skyBrightness.setter
@@ -355,6 +443,13 @@ class ObservationMetaData(object):
 
     @property
     def phoSimMetaData(self):
+        """
+        A dict of parameters expected by PhoSim characterizing this
+        ObservationMetaData.  Note that setting this paramter
+        could overwrite unrefractedRA, unrefractedDec, rotSkyPos,
+        MJD, or bandpass and m5 (if they are present in this
+        dict).
+        """
         return self._phoSimMetaData
 
     @phoSimMetaData.setter

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -35,7 +35,7 @@ class ObservationMetaData(object):
         * bandpassName : a char (e.g. 'u') or list (e.g. ['u', 'g', 'z'])
           denoting the bandpasses used for this particular observation
 
-        * phoSimMetadata : dict (optional)
+        * phoSimMetaData : dict (optional)
           a dictionary containing metadata used by PhoSim
 
         * m5: float or list (optional)
@@ -61,7 +61,7 @@ class ObservationMetaData(object):
     """
     def __init__(self, boundType=None, boundLength=None,
                  mjd=None, unrefractedRA=None, unrefractedDec=None, rotSkyPos=None,
-                 bandpassName=None, phoSimMetadata=None, site=Site(), m5=None, skyBrightness=None):
+                 bandpassName=None, phoSimMetaData=None, site=Site(), m5=None, skyBrightness=None):
 
         self._bounds = None
         self._boundType = boundType
@@ -90,15 +90,15 @@ class ObservationMetaData(object):
         else:
             self._boundLength = None
 
-        if phoSimMetadata is not None:
-            self.assignPhoSimMetaData(phoSimMetadata)
+        if phoSimMetaData is not None:
+            self._assignPhoSimMetaData(phoSimMetaData)
         else:
-            self._phoSimMetadata = None
+            self._phoSimMetaData = None
 
         self._assignM5(m5)
 
-        #this should be done after phoSimMetadata is assigned, just in case
-        #assignPhoSimMetadata overwrites unrefractedRA/Dec
+        #this should be done after phoSimMetaData is assigned, just in case
+        #self._assignPhoSimMetadata overwrites unrefractedRA/Dec
         if self._bounds is None:
             self._buildBounds()
 
@@ -119,7 +119,7 @@ class ObservationMetaData(object):
         mydict['skyBrightness'] = self.skyBrightness
         # mydict['m5'] = self.m5
 
-        mydict['phoSimMetadata'] = self.phoSimMetadata
+        mydict['phoSimMetaData'] = self.phoSimMetaData
 
         return mydict
 
@@ -180,47 +180,47 @@ class ObservationMetaData(object):
         self._bounds = SpatialBounds.getSpatialBounds(self._boundType, self._unrefractedRA, self._unrefractedDec,
                                                      self._boundLength)
 
-    def assignPhoSimMetaData(self, metaData):
+    def _assignPhoSimMetaData(self, metaData):
         """
         Assign the dict metaData to be the associated metadata dict of this object
         """
 
-        self._phoSimMetadata = metaData
+        self._phoSimMetaData = metaData
 
-        #overwrite member variables with values from the phoSimMetadata
-        if self._phoSimMetadata is not None and 'Opsim_expmjd' in self._phoSimMetadata:
+        #overwrite member variables with values from the phoSimMetaData
+        if self._phoSimMetaData is not None and 'Opsim_expmjd' in self._phoSimMetaData:
             if self._mjd is not None:
-                raise RuntimeError('WARNING in ObservationMetaData trying to overwrite mjd with phoSimMetadata')
+                raise RuntimeError('WARNING in ObservationMetaData trying to overwrite mjd with phoSimMetaData')
 
-            self._mjd = self._phoSimMetadata['Opsim_expmjd'][0]
+            self._mjd = self._phoSimMetaData['Opsim_expmjd'][0]
 
-        if self._phoSimMetadata is not None and 'Unrefracted_RA' in self._phoSimMetadata:
+        if self._phoSimMetaData is not None and 'Unrefracted_RA' in self._phoSimMetaData:
             if self._unrefractedRA is not None:
                 raise RuntimeError('WARNING in ObservationMetaData trying to overwrite unrefractedRA ' +
-                                   'with phoSimMetadata')
+                                   'with phoSimMetaData')
 
-            self._unrefractedRA = self._phoSimMetadata['Unrefracted_RA'][0]
+            self._unrefractedRA = self._phoSimMetaData['Unrefracted_RA'][0]
 
-        if self._phoSimMetadata is not None and 'Opsim_rotskypos' in self._phoSimMetadata:
+        if self._phoSimMetaData is not None and 'Opsim_rotskypos' in self._phoSimMetaData:
             if self._rotSkyPos is not None:
                 raise RuntimeError('WARNING in ObservationMetaData trying to overwrite rotSkyPos ' +
-                                   'with phoSimMetadata')
+                                   'with phoSimMetaData')
 
-            self._rotSkyPos = self.phoSimMetadata['Opsim_rotskypos'][0]
+            self._rotSkyPos = self.phoSimMetaData['Opsim_rotskypos'][0]
 
-        if self._phoSimMetadata is not None and 'Unrefracted_Dec' in self._phoSimMetadata:
+        if self._phoSimMetaData is not None and 'Unrefracted_Dec' in self._phoSimMetaData:
             if self._unrefractedDec is not None:
                 raise RuntimeError('WARNING in ObservationMetaData trying to overwrite unrefractedDec ' +
-                                   'with phoSimMetadata')
+                                   'with phoSimMetaData')
 
-            self._unrefractedDec = self._phoSimMetadata['Unrefracted_Dec'][0]
+            self._unrefractedDec = self._phoSimMetaData['Unrefracted_Dec'][0]
 
-        if self._phoSimMetadata is not None and 'Opsim_filter' in self._phoSimMetadata:
+        if self._phoSimMetaData is not None and 'Opsim_filter' in self._phoSimMetaData:
             if self._bandpass is not None:
                 raise RuntimeError('WARNING in ObservationMetaData trying to overwrite bandpass ' +
-                                   'with phoSimMetadata')
+                                   'with phoSimMetaData')
 
-            self._bandpass = self._phoSimMetadata['Opsim_filter'][0]
+            self._bandpass = self._phoSimMetaData['Opsim_filter'][0]
 
         self._buildBounds()
 
@@ -233,8 +233,8 @@ class ObservationMetaData(object):
 
     @unrefractedRA.setter
     def unrefractedRA(self, value):
-        if self._phoSimMetadata is not None:
-            if 'Unrefracted_RA' in self._phoSimMetadata:
+        if self._phoSimMetaData is not None:
+            if 'Unrefracted_RA' in self._phoSimMetaData:
                 raise RuntimeError('WARNING overwriting Unrefracted_RA ' +
                                    'which was set by phoSimMetaData')
 
@@ -250,8 +250,8 @@ class ObservationMetaData(object):
 
     @unrefractedDec.setter
     def unrefractedDec(self, value):
-        if self._phoSimMetadata is not None:
-            if 'Unrefracted_Dec' in self._phoSimMetadata:
+        if self._phoSimMetaData is not None:
+            if 'Unrefracted_Dec' in self._phoSimMetaData:
                 raise RuntimeError('WARNING overwriting Unrefracted_Dec ' +
                                    'which was set by phoSimMetaData')
 
@@ -289,11 +289,11 @@ class ObservationMetaData(object):
 
     @rotSkyPos.setter
     def rotSkyPos(self,value):
-        if self._phoSimMetadata is not None:
-            if 'Opsim_rotskypos' in self._phoSimMetadata:
+        if self._phoSimMetaData is not None:
+            if 'Opsim_rotskypos' in self._phoSimMetaData:
                 raise RuntimeError('WARNING overwriting rotSkyPos ' +
                                    'which was set by phoSimMetaData which was set ' +
-                                   'by phoSimMetadata')
+                                   'by phoSimMetaData')
 
         self._rotSkyPos = numpy.radians(value)
 
@@ -320,11 +320,11 @@ class ObservationMetaData(object):
 
     @mjd.setter
     def mjd(self, value):
-        if self._phoSimMetadata is not None:
-            if 'Opsim_expmjd' in self._phoSimMetadata:
+        if self._phoSimMetaData is not None:
+            if 'Opsim_expmjd' in self._phoSimMetaData:
                 raise RuntimeError('WARNING overwriting mjd ' +
                                    'which was set by phoSimMetaData which was set ' +
-                                   'by phoSimMetadata')
+                                   'by phoSimMetaData')
 
         self._mjd = value
 
@@ -336,11 +336,11 @@ class ObservationMetaData(object):
             return 'r'
 
     def setBandpassAndM5(self, bandpassName=None, m5=None):
-        if self._phoSimMetadata is not None:
-            if 'Opsim_filter' in self._phoSimMetadata:
+        if self._phoSimMetaData is not None:
+            if 'Opsim_filter' in self._phoSimMetaData:
                 raise RuntimeError('WARNING overwriting bandpass ' +
                                    'which was set by phoSimMetaData which was set ' +
-                                   'by phoSimMetadata')
+                                   'by phoSimMetaData')
 
         self._bandpass = bandpassName
         self._assignM5(m5)
@@ -354,11 +354,11 @@ class ObservationMetaData(object):
         self._skyBrightness = value
 
     @property
-    def phoSimMetadata(self):
-        return self._phoSimMetadata
+    def phoSimMetaData(self):
+        return self._phoSimMetaData
 
-    @phoSimMetadata.setter
-    def phoSimMetadata(self, value):
+    @phoSimMetaData.setter
+    def phoSimMetaData(self, value):
         if 'Unrefracted_RA' in value:
             self._unrefractedRA = None
 
@@ -375,4 +375,4 @@ class ObservationMetaData(object):
             self._bandpass = None
             self._m5 = None
 
-        self.assignPhoSimMetaData(value)
+        self._assignPhoSimMetaData(value)

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -340,7 +340,7 @@ class ObservationMetaData(object):
         if self._rotSkyPos is not None:
             return numpy.degrees(self._rotSkyPos)
         else:
-            return 0.0
+            return None
 
     @rotSkyPos.setter
     def rotSkyPos(self,value):

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -231,7 +231,7 @@ class ObservationMetaData(object):
                 raise RuntimeError('WARNING in ObservationMetaData trying to overwrite rotSkyPos ' +
                                    'with phoSimMetaData')
 
-            self._rotSkyPos = self.phoSimMetaData['Opsim_rotskypos'][0]
+            self._rotSkyPos = self._phoSimMetaData['Opsim_rotskypos'][0]
 
         if self._phoSimMetaData is not None and 'Unrefracted_Dec' in self._phoSimMetaData:
             if self._unrefractedDec is not None:

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -63,55 +63,55 @@ class ObservationMetaData(object):
                  mjd=None, unrefractedRA=None, unrefractedDec=None, rotSkyPos=0.0,
                  bandpassName='r', phoSimMetadata=None, site=None, m5=None, skyBrightness=None):
 
-        self.bounds = None
-        self.boundType = boundType
-        self.mjd = mjd
-        self.bandpass = bandpassName
-        self.skyBrightness = skyBrightness
+        self._bounds = None
+        self._boundType = boundType
+        self._mjd = mjd
+        self._bandpass = bandpassName
+        self._skyBrightness = skyBrightness
 
         if rotSkyPos is not None:
-            self.rotSkyPos = numpy.radians(rotSkyPos)
+            self._rotSkyPos = numpy.radians(rotSkyPos)
         else:
-            self.rotSkyPos = None
+            self._rotSkyPos = None
 
         if unrefractedRA is not None:
-            self.unrefractedRA = numpy.radians(unrefractedRA)
+            self._unrefractedRA = numpy.radians(unrefractedRA)
         else:
-            self.unrefractedRA = None
+            self._unrefractedRA = None
 
         if unrefractedDec is not None:
-            self.unrefractedDec = numpy.radians(unrefractedDec)
+            self._unrefractedDec = numpy.radians(unrefractedDec)
         else:
-            self.unrefractedDec = None
+            self._unrefractedDec = None
 
         if boundLength is not None:
             if isinstance(boundLength, float):
-                self.boundLength = numpy.radians(boundLength)
+                self._boundLength = numpy.radians(boundLength)
             else:
                 try:
-                    self.boundLength = []
+                    self._boundLength = []
                     for ll in boundLength:
-                        self.boundLength.append(numpy.radians(ll))
+                        self._boundLength.append(numpy.radians(ll))
                 except:
                     raise RuntimeError("You seem to have passed something that is neither a float nor " +
                                        "list-like as boundLength to ObservationMetaData")
         else:
-            self.boundLength = None
+            self._boundLength = None
 
         if site is not None:
-            self.site=site
+            self._site=site
         else:
-            self.site=Site()
+            self._site=Site()
 
         if site is not None:
-            self.site=site
+            self._site=site
         else:
-            self.site=Site()
+            self._site=Site()
 
         if phoSimMetadata is not None:
             self.assignPhoSimMetaData(phoSimMetadata)
         else:
-            self.phoSimMetadata = None
+            self._phoSimMetadata = None
 
         #this should be done after phoSimMetadata is assigned, just in case
         #assignPhoSimMetadata overwrites unrefractedRA/Dec
@@ -119,7 +119,7 @@ class ObservationMetaData(object):
             self.buildBounds()
 
         if m5 is None:
-            self.m5 = None
+            self._m5 = None
         else:
             bandpassIsList = False
             m5IsList = False
@@ -145,11 +145,11 @@ class ObservationMetaData(object):
 
             #now build the m5 dict
             if bandpassIsList:
-                self.m5 = {}
-                for b, m in zip(self.bandpass, m5):
-                    self.m5[b] = m
+                self._m5 = {}
+                for b, m in zip(self._bandpass, m5):
+                    self._m5[b] = m
             else:
-                self.m5 = {self.bandpass:m5}
+                self._m5 = {self._bandpass:m5}
 
     @property
     def summary(self):
@@ -172,43 +172,90 @@ class ObservationMetaData(object):
         return mydict
 
     def buildBounds(self):
-        if self.boundType is None:
+        if self._boundType is None:
             return
 
-        if self.boundLength is None:
+        if self._boundLength is None:
             raise RuntimeError("ObservationMetadata cannot assign a bounds; it has no boundLength")
 
-        if self.unrefractedRA is None or self.unrefractedDec is None:
+        if self._unrefractedRA is None or self._unrefractedDec is None:
             raise RuntimeError("ObservationMetadata cannot assign a bounds; it has no unrefractedRA/Dec")
 
-        self.bounds = SpatialBounds.getSpatialBounds(self.boundType, self.unrefractedRA, self.unrefractedDec,
-                                                     self.boundLength)
+        self._bounds = SpatialBounds.getSpatialBounds(self._boundType, self._unrefractedRA, self._unrefractedDec,
+                                                     self._boundLength)
 
     def assignPhoSimMetaData(self, metaData):
         """
         Assign the dict metaData to be the associated metadata dict of this object
         """
 
-        self.phoSimMetadata = metaData
+        self._phoSimMetadata = metaData
 
         #overwrite member variables with values from the phoSimMetadata
-        if self.phoSimMetadata is not None and 'Opsim_expmjd' in self.phoSimMetadata:
-            self.mjd = self.phoSimMetadata['Opsim_expmjd'][0]
+        if self._phoSimMetadata is not None and 'Opsim_expmjd' in self._phoSimMetadata:
+            self._mjd = self._phoSimMetadata['Opsim_expmjd'][0]
 
-        if self.phoSimMetadata is not None and 'Unrefracted_RA' in self.phoSimMetadata:
-            self.unrefractedRA = self.phoSimMetadata['Unrefracted_RA'][0]
+        if self._phoSimMetadata is not None and 'Unrefracted_RA' in self._phoSimMetadata:
+            self._unrefractedRA = self._phoSimMetadata['Unrefracted_RA'][0]
 
-        if self.phoSimMetadata is not None and 'Opsim_rotskypos' in self.phoSimMetadata:
-            self.rotSkyPos = self.phoSimMetadata['Opsim_rotskypos'][0]
+        if self._phoSimMetadata is not None and 'Opsim_rotskypos' in self._phoSimMetadata:
+            self._rotSkyPos = self.phoSimMetadata['Opsim_rotskypos'][0]
 
-        if self.phoSimMetadata is not None and 'Unrefracted_Dec' in self.phoSimMetadata:
-            self.unrefractedDec = self.phoSimMetadata['Unrefracted_Dec'][0]
+        if self._phoSimMetadata is not None and 'Unrefracted_Dec' in self._phoSimMetadata:
+            self._unrefractedDec = self._phoSimMetadata['Unrefracted_Dec'][0]
 
-        if self.phoSimMetadata is not None and 'Opsim_filter' in self.phoSimMetadata:
-            self.bandpass = self.phoSimMetadata['Opsim_filter'][0]
+        if self._phoSimMetadata is not None and 'Opsim_filter' in self._phoSimMetadata:
+            self._bandpass = self._phoSimMetadata['Opsim_filter'][0]
 
         #in case this method was called after __init__ and unrefractedRA/Dec were
         #overwritten by this method
-        if self.bounds is not None:
+        if self._bounds is not None:
             self.buildBounds()
 
+    @property
+    def unrefractedRA(self):
+        return self._unrefractedRA
+
+    @property
+    def unrefractedDec(self):
+        return self._unrefractedDec
+
+    @property
+    def boundLength(self):
+        return self._boundLength
+
+    @property
+    def boundType(self):
+        return self._boundType
+
+    @property
+    def bounds(self):
+        return self._bounds
+
+    @property
+    def rotSkyPos(self):
+        return self._rotSkyPos
+
+    @property
+    def m5(self):
+        return self._m5
+
+    @property
+    def site(self):
+        return self._site
+
+    @property
+    def mjd(self):
+        return self._mjd
+
+    @property
+    def bandpass(self):
+        return self._bandpass
+
+    @property
+    def skyBrightness(self):
+        return self._skyBrightness
+
+    @property
+    def phoSimMetadata(self):
+        return self._phoSimMetadata

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -335,14 +335,14 @@ class ObservationMetaData(object):
         else:
             return 'r'
 
-    def setBandpassAndM5(self, bandpass=None, m5=None):
+    def setBandpassAndM5(self, bandpassName=None, m5=None):
         if self._phoSimMetadata is not None:
             if 'Opsim_filter' in self._phoSimMetadata:
                 raise RuntimeError('WARNING overwriting bandpass ' +
                                    'which was set by phoSimMetaData which was set ' +
                                    'by phoSimMetadata')
 
-        self._bandpass = bandpass
+        self._bandpass = bandpassName
         self.assignM5(m5)
 
     @property

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -95,7 +95,7 @@ class ObservationMetaData(object):
         else:
             self._phoSimMetadata = None
 
-        self.assignM5(m5)
+        self._assignM5(m5)
 
         #this should be done after phoSimMetadata is assigned, just in case
         #assignPhoSimMetadata overwrites unrefractedRA/Dec
@@ -123,7 +123,7 @@ class ObservationMetaData(object):
 
         return mydict
 
-    def assignM5(self, m5):
+    def _assignM5(self, m5):
 
         if m5 is None:
             self._m5 = None
@@ -304,7 +304,7 @@ class ObservationMetaData(object):
 
     @m5.setter
     def m5(self, value):
-        self.assignM5(value)
+        self._assignM5(value)
 
     @property
     def site(self):
@@ -343,7 +343,7 @@ class ObservationMetaData(object):
                                    'by phoSimMetadata')
 
         self._bandpass = bandpassName
-        self.assignM5(m5)
+        self._assignM5(m5)
 
     @property
     def skyBrightness(self):

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -344,7 +344,7 @@ class ObservationMetaData(object):
         else:
             return 'r'
 
-    def setBandpassAndM5(self, bandpass, m5):
+    def setBandpassAndM5(self, bandpass=None, m5=None):
         if self._phoSimMetadata is not None:
             if 'Opsim_filter' in self._phoSimMetadata:
                 raise RuntimeError('WARNING overwriting bandpass ' +

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -245,8 +245,7 @@ class ObservationMetaData(object):
         if self._phoSimMetadata is not None:
             if 'Unrefracted_RA' in self._phoSimMetadata:
                 raise RuntimeError('WARNING overwriting Unrefracted_RA ' +
-                                   'which was set by phoSimMetaData which was set ' +
-                                   'by phoSimMetadata')
+                                   'which was set by phoSimMetaData')
 
         self._unrefractedRA = numpy.degrees(value)
         self.buildBounds()
@@ -263,8 +262,7 @@ class ObservationMetaData(object):
         if self._phoSimMetadata is not None:
             if 'Unrefracted_Dec' in self._phoSimMetadata:
                 raise RuntimeError('WARNING overwriting Unrefracted_Dec ' +
-                                   'which was set by phoSimMetaData which was set ' +
-                                   'by phoSimMetadata')
+                                   'which was set by phoSimMetaData')
 
         self._unrefractedDec = numpy.radians(value)
         self.buildBounds()

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -235,7 +235,10 @@ class ObservationMetaData(object):
 
     @property
     def unrefractedRA(self):
-        return self._unrefractedRA
+        if self._unrefractedRA is not None:
+            return numpy.degrees(self._unrefractedRA)
+        else:
+            return None
 
     @unrefractedRA.setter
     def unrefractedRA(self, value):
@@ -250,7 +253,10 @@ class ObservationMetaData(object):
 
     @property
     def unrefractedDec(self):
-        return self._unrefractedDec
+        if self._unrefractedDec is not None:
+            return numpy.degrees(self._unrefractedDec)
+        else:
+            return None
 
     @unrefractedDec.setter
     def unrefractedDec(self, value):

--- a/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
+++ b/python/lsst/sims/catalogs/generation/db/ObservationMetaData.py
@@ -205,7 +205,7 @@ class ObservationMetaData(object):
         Assign the dict metaData to be the associated phoSimMetaData dict of this object.
 
         In doing so, this method will copy unrefractedRA, unrefractedDec, rotSkyPos,
-        MJD, and bandpass from the phoSimMetaData (if present) to the corresponding
+        MJD, and bandpass from the metaData (if present) to the corresponding
         member variables.  If by doing so you try to overwrite a parameter that you
         have already set by hand, this method will raise an exception.
         """

--- a/python/lsst/sims/catalogs/generation/db/spatialBounds.py
+++ b/python/lsst/sims/catalogs/generation/db/spatialBounds.py
@@ -110,19 +110,19 @@ class CircleBounds(SpatialBounds):
             try:
                 ra = np.float(ra)
             except:
-                raise RuntimeError('in CircleBounds, ra must be a float')
+                raise RuntimeError('in CircleBounds, ra must be a float; you have %s' % type(ra))
 
         if not (isinstance(dec, float) or isinstance(dec, np.float)):
             try:
                 dec = np.float(dec)
             except:
-                raise RuntimeError('in CircleBounds, dec must be a float')
+                raise RuntimeError('in CircleBounds, dec must be a float; you hve %s' % type(dec))
 
         if not (isinstance(radius, float) or isinstance(radius, np.float)):
             try:
                 radius = np.float(radius)
             except:
-                raise RuntimeError('in CircleBounds, radius must be a float')
+                raise RuntimeError('in CircleBounds, radius must be a float; you have %s' % type(radius))
 
         self.RA = ra
         self.DEC = dec
@@ -185,13 +185,13 @@ class BoxBounds(SpatialBounds):
             try:
                 ra = np.float(ra)
             except:
-                raise RuntimeError('in BoxBounds ra must be a float')
+                raise RuntimeError('in BoxBounds ra must be a float; you have %s' % type(ra))
 
         if not (isinstance(dec, float) or isinstance(dec, np.float)):
             try:
                 dec = np.float(dec)
             except:
-                raise RuntimeError('in BoxBounds dec must be a float')
+                raise RuntimeError('in BoxBounds dec must be a float; you have %s' % type(dec))
 
         self.RA = ra
         self.DEC = dec

--- a/python/lsst/sims/catalogs/generation/db/spatialBounds.py
+++ b/python/lsst/sims/catalogs/generation/db/spatialBounds.py
@@ -104,6 +104,26 @@ class CircleBounds(SpatialBounds):
         @param[in] length is the radius of the field of view in radians
         """
 
+
+
+        if not (isinstance(ra, float) or isinstance(ra, np.float)):
+            try:
+                ra = np.float(ra)
+            except:
+                raise RuntimeError('in CircleBounds, ra must be a float')
+
+        if not (isinstance(dec, float) or isinstance(dec, np.float)):
+            try:
+                dec = np.float(dec)
+            except:
+                raise RuntimeError('in CircleBounds, dec must be a float')
+
+        if not (isinstance(radius, float) or isinstance(radius, np.float)):
+            try:
+                radius = np.float(radius)
+            except:
+                raise RuntimeError('in CircleBounds, radius must be a float')
+
         self.RA = ra
         self.DEC = dec
         self.radius = radius
@@ -160,24 +180,40 @@ class BoxBounds(SpatialBounds):
         If it is a list/tuple/array, the field of view will be a rectangle with side lengths
         RA = 2 x length[0] and Dec = 2 x length[1]
         """
+
+        if not (isinstance(ra, float) or isinstance(ra, np.float)):
+            try:
+                ra = np.float(ra)
+            except:
+                raise RuntimeError('in BoxBounds ra must be a float')
+
+        if not (isinstance(dec, float) or isinstance(dec, np.float)):
+            try:
+                dec = np.float(dec)
+            except:
+                raise RuntimeError('in BoxBounds dec must be a float')
+
         self.RA = ra
         self.DEC = dec
 
         self.RAdeg = np.degrees(ra)
         self.DECdeg = np.degrees(dec)
 
-        if isinstance(length, float):
-            lengthRAdeg = np.degrees(length)
-            lengthDECdeg = np.degrees(length)
-        elif len(length)==1:
-            lengthRAdeg = np.degrees(length[0])
-            lengthDECdeg = np.degrees(length[0])
-        else:
-            try:
-                lengthRAdeg = np.degrees(length[0])
-                lengthDECdeg = np.degrees(length[1])
-            except:
-                raise RuntimeError("BoxBounds is unsure how to handle length %s " % str(length))
+        try:
+            if hasattr(length, '__len__'):
+                if len(length) == 1:
+                    lengthRAdeg = np.degrees(length[0])
+                    lengthDECdeg = np.degrees(length[0])
+                else:
+                    lengthRAdeg = np.degrees(length[0])
+                    lengthDECdeg = np.degrees(length[1])
+            else:
+                length = np.float(length)
+                lengthRAdeg = np.degrees(length)
+                lengthDECdeg = np.degrees(length)
+
+        except:
+            raise RuntimeError("BoxBounds is unsure how to handle length %s type: %s" % (str(length),type(length)))
 
         self.RAminDeg = self.RAdeg - lengthRAdeg
         self.RAmaxDeg = self.RAdeg + lengthRAdeg

--- a/python/lsst/sims/catalogs/generation/utils/testUtils.py
+++ b/python/lsst/sims/catalogs/generation/utils/testUtils.py
@@ -313,11 +313,11 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
                  testSite.longitude, testSite.latitude)
 
     obsDict['Opsim_expmjd'] = mjd
-    phoSimMetadata = OrderedDict([
+    phoSimMetaData = OrderedDict([
                       (k, (obsDict[k],numpy.dtype(type(obsDict[k])))) for k in obsDict])
 
     obs_metadata = ObservationMetaData(boundType = 'circle', boundLength = 2.0*radius,
-                                       phoSimMetadata=phoSimMetadata, site=testSite)
+                                       phoSimMetaData=phoSimMetaData, site=testSite)
 
     #Now begin building the database.
     #First create the tables.

--- a/python/lsst/sims/catalogs/generation/utils/testUtils.py
+++ b/python/lsst/sims/catalogs/generation/utils/testUtils.py
@@ -316,8 +316,7 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
     phoSimMetadata = OrderedDict([
                       (k, (obsDict[k],numpy.dtype(type(obsDict[k])))) for k in obsDict])
 
-    obs_metadata = ObservationMetaData(boundType = 'circle', unrefractedRA = numpy.degrees(centerRA),
-                                       unrefractedDec = numpy.degrees(centerDec), boundLength = 2.0*radius,
+    obs_metadata = ObservationMetaData(boundType = 'circle', boundLength = 2.0*radius,
                                        phoSimMetadata=phoSimMetadata, site=testSite)
 
     #Now begin building the database.

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -33,8 +33,14 @@ class ObservationMetaDataTest(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             obs_metadata.unrefractedRA=1.2
+
+        with self.assertRaises(RuntimeError):
             obs_metadata.unrefractedDec=1.2
+
+        with self.assertRaises(RuntimeError):
             obs_metadata.rotSkyPos=1.5
+
+        with self.assertRaises(RuntimeError):
             obs_metadata.setBandpassAndM5()
 
         obs_metadata = ObservationMetaData(unrefractedRA=1.5,

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -153,21 +153,11 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertEqual(testObsMD.bandpass,'g')
 
 
-    def testBoundExceptions(self):
+    def testBoundBuilding(self):
         """
-        Make sure ObservationMetaData throws an error when you incorrectly set Bounds
+        Make sure ObservationMetaData can build bounds
         """
-
-        self.assertRaises(RuntimeError,ObservationMetaData,boundType='hex',
-                          boundLength=1.0,unrefractedRA=0.0,unrefractedDec=0.0)
-        self.assertRaises(RuntimeError,ObservationMetaData,boundType='box',unrefractedRA=0.0,unrefractedDec=0.0)
-        self.assertRaises(RuntimeError,ObservationMetaData,boundType='box',unrefractedRA=0.0,boundLength=1.0)
-        self.assertRaises(RuntimeError,ObservationMetaData,boundType='box',unrefractedDec=0.0,boundLength=1.0)
-
-        boxBounds = numpy.array([1.0,2.0])
-        self.assertRaises(RuntimeError,ObservationMetaData,boundType='box',unrefractedRA=0.0,boundLength=boxBounds)
-        self.assertRaises(RuntimeError,ObservationMetaData,boundType='box',unrefractedDec=0.0,boundLength=boxBounds)
-
+        boxBounds = [0.1, 0.3]
         circObs = ObservationMetaData(boundType='circle',unrefractedRA=0.0, unrefractedDec=0.0, boundLength=1.0)
         squareObs = ObservationMetaData(boundType = 'box',unrefractedRA=0.0, unrefractedDec=0.0, boundLength=1.0)
         boxObs = ObservationMetaData(boundType = 'box', unrefractedRA=0.0, unrefractedDec=0.0, boundLength=boxBounds)

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -141,6 +141,17 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertAlmostEqual(testObsMD.rotSkyPos,1.1,10)
         self.assertEqual(testObsMD.bandpass,'g')
 
+        testObsMD = ObservationMetaData()
+        testObsMD.phoSimMetadata = phosimMD
+
+        self.assertAlmostEqual(testObsMD.mjd,4000.0,10)
+
+        #recall that Unrefracted_RA/Dec are stored as radians in phoSim metadata
+        self.assertAlmostEqual(testObsMD.unrefractedRA,numpy.degrees(-2.0),10)
+        self.assertAlmostEqual(testObsMD.unrefractedDec,numpy.degrees(0.9),10)
+        self.assertAlmostEqual(testObsMD.rotSkyPos,1.1,10)
+        self.assertEqual(testObsMD.bandpass,'g')
+
 
     def testBoundExceptions(self):
         """

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -67,6 +67,31 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertEqual(obsMD.m5['g'], 11)
         self.assertEqual(obsMD.m5['r'], 12)
 
+
+    def testM5Assignment(self):
+        """
+        Test assignment of M5 and bandpass in ObservationMetaData
+        """
+        obsMD = ObservationMetaData(bandpassName=['u','g'], m5=[12.0, 11.0])
+        self.assertAlmostEqual(obsMD.m5['u'], 12.0, 10)
+        self.assertAlmostEqual(obsMD.m5['g'], 11.0, 10)
+
+        obsMD.setBandpassAndM5(bandpassName=['i','z'], m5=[25.0, 22.0])
+        self.assertAlmostEqual(obsMD.m5['i'], 25.0, 10)
+        self.assertAlmostEqual(obsMD.m5['z'], 22.0, 10)
+
+        with self.assertRaises(KeyError):
+            obsMD.m5['u']
+
+        with self.assertRaises(KeyError):
+            obsMD.m5['g']
+
+        phoSimMD = {'Opsim_filter':[4]}
+        obsMD.phoSimMetadata = phoSimMD
+        self.assertEqual(obsMD.bandpass, 4)
+        self.assertTrue(obsMD.m5 is None)
+
+
     def testDefault(self):
         """
         Test that ObservationMetaData's default variables are properly set

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -126,6 +126,7 @@ class ObservationMetaDataTest(unittest.TestCase):
         testObsMD.skyBrightness = skyBrightness
         testObsMD.boundType = 'box'
         testObsMD.boundLength = [1.2, 3.0]
+        testObsMD.mjd = mjd
 
         self.assertAlmostEqual(testObsMD.unrefractedRA, RA, 10)
         self.assertAlmostEqual(testObsMD.unrefractedDec, Dec, 10)
@@ -134,6 +135,39 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertEqual(testObsMD.boundType, 'box')
         self.assertAlmostEqual(testObsMD.boundLength[0],1.2, 10)
         self.assertAlmostEqual(testObsMD.boundLength[1], 3.0, 10)
+        self.assertAlmostEqual(testObsMD.mjd, mjd, 10)
+
+        #test reassignment
+
+        testObsMD.unrefractedRA = RA+1.0
+        testObsMD.unrefractedDec = Dec+1.0
+        testObsMD.rotSkyPos = rotSkyPos+1.0
+        testObsMD.skyBrightness = skyBrightness+1.0
+        testObsMD.boundLength = 2.2
+        testObsMD.boundType = 'circle'
+        testObsMD.mjd = mjd + 10.0
+
+        self.assertAlmostEqual(testObsMD.unrefractedRA, RA+1.0, 10)
+        self.assertAlmostEqual(testObsMD.unrefractedDec, Dec+1.0, 10)
+        self.assertAlmostEqual(testObsMD.rotSkyPos, rotSkyPos+1.0, 10)
+        self.assertAlmostEqual(testObsMD.skyBrightness, skyBrightness+1.0, 10)
+        self.assertEqual(testObsMD.boundType, 'circle')
+        self.assertAlmostEqual(testObsMD.boundLength,2.2, 10)
+        self.assertAlmostEqual(testObsMD.mjd, mjd+10.0, 10)
+
+        phosimMD = OrderedDict([('Unrefracted_RA', (-2.0,float)),
+                                ('Unrefracted_Dec', (0.9,float)),
+                                ('Opsim_rotskypos', (1.1,float)),
+                                ('Opsim_expmjd',(4000.0,float)),
+                                ('Opsim_filter',('g',str))])
+
+
+        testObsMD.phoSimMetadata = phosimMD
+        self.assertAlmostEqual(testObsMD.unrefractedRA, numpy.degrees(-2.0), 10)
+        self.assertAlmostEqual(testObsMD.unrefractedDec, numpy.degrees(0.9), 10)
+        self.assertAlmostEqual(testObsMD.rotSkyPos, numpy.degrees(1.1))
+        self.assertAlmostEqual(testObsMD.mjd, 4000.0, 10)
+        self.assertAlmostEqual(testObsMD.bandpass, 'g')
 
         testObsMD = ObservationMetaData(mjd=mjd, unrefractedRA=RA,
             unrefractedDec=Dec, rotSkyPos=rotSkyPos, bandpassName='z',
@@ -145,12 +179,6 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertAlmostEqual(testObsMD.rotSkyPos,-10.0,10)
         self.assertEqual(testObsMD.bandpass,'z')
         self.assertAlmostEqual(testObsMD.skyBrightness, skyBrightness, 10)
-
-        phosimMD = OrderedDict([('Unrefracted_RA', (-2.0,float)),
-                                ('Unrefracted_Dec', (0.9,float)),
-                                ('Opsim_rotskypos', (1.1,float)),
-                                ('Opsim_expmjd',(4000.0,float)),
-                                ('Opsim_filter',('g',str))])
 
         testObsMD = ObservationMetaData()
         testObsMD.assignPhoSimMetaData(phosimMD)

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -90,8 +90,8 @@ class ObservationMetaDataTest(unittest.TestCase):
             skyBrightness=skyBrightness)
 
         self.assertAlmostEqual(testObsMD.mjd,5120.0,10)
-        self.assertAlmostEqual(numpy.degrees(testObsMD.unrefractedRA),1.5,10)
-        self.assertAlmostEqual(numpy.degrees(testObsMD.unrefractedDec),-1.1,10)
+        self.assertAlmostEqual(testObsMD.unrefractedRA,1.5,10)
+        self.assertAlmostEqual(testObsMD.unrefractedDec,-1.1,10)
         self.assertAlmostEqual(numpy.degrees(testObsMD.rotSkyPos),-10.0,10)
         self.assertEqual(testObsMD.bandpass,'z')
         self.assertAlmostEqual(testObsMD.skyBrightness, skyBrightness, 10)
@@ -108,8 +108,8 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertAlmostEqual(testObsMD.mjd,4000.0,10)
 
         #recall that Unrefracted_RA/Dec are stored as radians in phoSim metadata
-        self.assertAlmostEqual(testObsMD.unrefractedRA,-2.0,10)
-        self.assertAlmostEqual(testObsMD.unrefractedDec,0.9,10)
+        self.assertAlmostEqual(testObsMD.unrefractedRA,numpy.degrees(-2.0),10)
+        self.assertAlmostEqual(testObsMD.unrefractedDec,numpy.degrees(0.9),10)
         self.assertAlmostEqual(testObsMD.rotSkyPos,1.1,10)
         self.assertEqual(testObsMD.bandpass,'g')
 
@@ -149,13 +149,13 @@ class ObservationMetaDataTest(unittest.TestCase):
 
         testObsMD = ObservationMetaData(boundType='circle',
                      unrefractedRA = circRA, unrefractedDec=circDec, boundLength = radius)
-        self.assertAlmostEqual(numpy.degrees(testObsMD.unrefractedRA),25.0,10)
-        self.assertAlmostEqual(numpy.degrees(testObsMD.unrefractedDec),50.0,10)
+        self.assertAlmostEqual(testObsMD.unrefractedRA,25.0,10)
+        self.assertAlmostEqual(testObsMD.unrefractedDec,50.0,10)
 
         testObsMD = ObservationMetaData(boundType = 'box',
                                         unrefractedRA = boxRA, unrefractedDec = boxDec, boundLength=boxLength)
-        self.assertAlmostEqual(numpy.degrees(testObsMD.unrefractedRA),15.0,10)
-        self.assertAlmostEqual(numpy.degrees(testObsMD.unrefractedDec),0.0,10)
+        self.assertAlmostEqual(testObsMD.unrefractedRA,15.0,10)
+        self.assertAlmostEqual(testObsMD.unrefractedDec,0.0,10)
 
 def suite():
     """Returns a suite containing all the test cases in this module."""

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -101,7 +101,7 @@ class ObservationMetaDataTest(unittest.TestCase):
 
         self.assertEqual(testObsMD.unrefractedRA,None)
         self.assertEqual(testObsMD.unrefractedDec,None)
-        self.assertAlmostEqual(testObsMD.rotSkyPos,0.0,10)
+        self.assertEqual(testObsMD.rotSkyPos,None)
         self.assertEqual(testObsMD.bandpass,'r')
         self.assertAlmostEqual(testObsMD.site.longitude,-1.2320792,10)
         self.assertAlmostEqual(testObsMD.site.latitude,-0.517781017,10)

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -102,6 +102,7 @@ class ObservationMetaDataTest(unittest.TestCase):
                                 ('Opsim_expmjd',(4000.0,float)),
                                 ('Opsim_filter',('g',str))])
 
+        testObsMD = ObservationMetaData()
         testObsMD.assignPhoSimMetaData(phosimMD)
 
         self.assertAlmostEqual(testObsMD.mjd,4000.0,10)
@@ -111,6 +112,7 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertAlmostEqual(testObsMD.unrefractedDec,0.9,10)
         self.assertAlmostEqual(testObsMD.rotSkyPos,1.1,10)
         self.assertEqual(testObsMD.bandpass,'g')
+
 
     def testBoundExceptions(self):
         """

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -27,7 +27,7 @@ class ObservationMetaDataTest(unittest.TestCase):
                     'Opsim_rotskypos':[1.3],
                     'Opsim_filter':[2]}
 
-        obs_metadata = ObservationMetaData(phoSimMetadata=metadata,
+        obs_metadata = ObservationMetaData(phoSimMetaData=metadata,
                                            boundType='circle',
                                            boundLength=0.1)
 
@@ -87,7 +87,7 @@ class ObservationMetaDataTest(unittest.TestCase):
             obsMD.m5['g']
 
         phoSimMD = {'Opsim_filter':[4]}
-        obsMD.phoSimMetadata = phoSimMD
+        obsMD.phoSimMetaData = phoSimMD
         self.assertEqual(obsMD.bandpass, 4)
         self.assertTrue(obsMD.m5 is None)
 
@@ -187,7 +187,7 @@ class ObservationMetaDataTest(unittest.TestCase):
                                 ('Opsim_filter',('g',str))])
 
 
-        testObsMD.phoSimMetadata = phosimMD
+        testObsMD.phoSimMetaData = phosimMD
         self.assertAlmostEqual(testObsMD.unrefractedRA, numpy.degrees(-2.0), 10)
         self.assertAlmostEqual(testObsMD.unrefractedDec, numpy.degrees(0.9), 10)
         self.assertAlmostEqual(testObsMD.rotSkyPos, numpy.degrees(1.1))
@@ -206,7 +206,7 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertAlmostEqual(testObsMD.skyBrightness, skyBrightness, 10)
 
         testObsMD = ObservationMetaData()
-        testObsMD.assignPhoSimMetaData(phosimMD)
+        testObsMD.phoSimMetaData = phosimMD
 
         self.assertAlmostEqual(testObsMD.mjd,4000.0,10)
 
@@ -217,7 +217,7 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertEqual(testObsMD.bandpass,'g')
 
         testObsMD = ObservationMetaData()
-        testObsMD.phoSimMetadata = phosimMD
+        testObsMD.phoSimMetaData = phosimMD
 
         self.assertAlmostEqual(testObsMD.mjd,4000.0,10)
 

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -119,6 +119,22 @@ class ObservationMetaDataTest(unittest.TestCase):
         rotSkyPos = -10.0
         skyBrightness = 25.0
 
+        testObsMD = ObservationMetaData()
+        testObsMD.unrefractedRA = RA
+        testObsMD.unrefractedDec = Dec
+        testObsMD.rotSkyPos = rotSkyPos
+        testObsMD.skyBrightness = skyBrightness
+        testObsMD.boundType = 'box'
+        testObsMD.boundLength = [1.2, 3.0]
+
+        self.assertAlmostEqual(testObsMD.unrefractedRA, RA, 10)
+        self.assertAlmostEqual(testObsMD.unrefractedDec, Dec, 10)
+        self.assertAlmostEqual(testObsMD.rotSkyPos, rotSkyPos, 10)
+        self.assertAlmostEqual(testObsMD.skyBrightness, skyBrightness, 10)
+        self.assertEqual(testObsMD.boundType, 'box')
+        self.assertAlmostEqual(testObsMD.boundLength[0],1.2, 10)
+        self.assertAlmostEqual(testObsMD.boundLength[1], 3.0, 10)
+
         testObsMD = ObservationMetaData(mjd=mjd, unrefractedRA=RA,
             unrefractedDec=Dec, rotSkyPos=rotSkyPos, bandpassName='z',
             skyBrightness=skyBrightness)
@@ -126,7 +142,7 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertAlmostEqual(testObsMD.mjd,5120.0,10)
         self.assertAlmostEqual(testObsMD.unrefractedRA,1.5,10)
         self.assertAlmostEqual(testObsMD.unrefractedDec,-1.1,10)
-        self.assertAlmostEqual(numpy.degrees(testObsMD.rotSkyPos),-10.0,10)
+        self.assertAlmostEqual(testObsMD.rotSkyPos,-10.0,10)
         self.assertEqual(testObsMD.bandpass,'z')
         self.assertAlmostEqual(testObsMD.skyBrightness, skyBrightness, 10)
 
@@ -144,7 +160,7 @@ class ObservationMetaDataTest(unittest.TestCase):
         #recall that Unrefracted_RA/Dec are stored as radians in phoSim metadata
         self.assertAlmostEqual(testObsMD.unrefractedRA,numpy.degrees(-2.0),10)
         self.assertAlmostEqual(testObsMD.unrefractedDec,numpy.degrees(0.9),10)
-        self.assertAlmostEqual(testObsMD.rotSkyPos,1.1,10)
+        self.assertAlmostEqual(testObsMD.rotSkyPos,numpy.degrees(1.1),10)
         self.assertEqual(testObsMD.bandpass,'g')
 
         testObsMD = ObservationMetaData()
@@ -155,7 +171,7 @@ class ObservationMetaDataTest(unittest.TestCase):
         #recall that Unrefracted_RA/Dec are stored as radians in phoSim metadata
         self.assertAlmostEqual(testObsMD.unrefractedRA,numpy.degrees(-2.0),10)
         self.assertAlmostEqual(testObsMD.unrefractedDec,numpy.degrees(0.9),10)
-        self.assertAlmostEqual(testObsMD.rotSkyPos,1.1,10)
+        self.assertAlmostEqual(testObsMD.rotSkyPos,numpy.degrees(1.1),10)
         self.assertEqual(testObsMD.bandpass,'g')
 
 

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -1,3 +1,5 @@
+from __future__ import with_statement
+
 import os
 import numpy
 import unittest
@@ -13,6 +15,32 @@ class ObservationMetaDataTest(unittest.TestCase):
 
     It will also test the behavior of the m5 member variable.
     """
+
+    def testExceptions(self):
+        """
+        Test that errors are produced whenever ObservationMetaData
+        parameters are overwritten in an unintentional way
+        """
+
+        metadata = {'Unrefracted_RA':[1.5], 'Unrefracted_Dec':[0.5],
+                    'Opsim_expmjd':[52000.0],
+                    'Opsim_rotskypos':[1.3],
+                    'Opsim_filter':[2]}
+
+        obs_metadata = ObservationMetaData(phoSimMetadata=metadata,
+                                           boundType='circle',
+                                           boundLength=0.1)
+
+        with self.assertRaises(RuntimeError):
+            obs_metadata.unrefractedRA=1.2
+            obs_metadata.unrefractedDec=1.2
+            obs_metadata.rotSkyPos=1.5
+            obs_metadata.setBandpassAndM5()
+
+        obs_metadata = ObservationMetaData(unrefractedRA=1.5,
+                                           unrefractedDec=1.5)
+
+
     def testM5(self):
         """
         Test behavior of ObservationMetaData's m5 member variable

--- a/tests/testSpatialBounds.py
+++ b/tests/testSpatialBounds.py
@@ -1,10 +1,42 @@
+from __future__ import with_statement
+
 import os
 import numpy
 import unittest
 import lsst.utils.tests as utilsTests
 from lsst.sims.catalogs.generation.db.spatialBounds import SpatialBounds
+from lsst.sims.catalogs.generation.db import CircleBounds, BoxBounds
 
 class SpatialBoundsTest(unittest.TestCase):
+
+    def testExceptions(self):
+        """
+        Test that the spatial bound classes raise exceptions when you
+        give them improperly formatted arguments
+        """
+
+        with self.assertRaises(RuntimeError):
+            circ = CircleBounds(1.0, 2.0, [3.0,4.0])
+
+        with self.assertRaises(RuntimeError):
+            circ = CircleBounds('a',2.0,3.0)
+
+        with self.assertRaises(RuntimeError):
+            circ = CircleBounds(1.0, 'b', 4.0)
+
+        circ = CircleBounds(1.0,2.0,3)
+
+        with self.assertRaises(RuntimeError):
+            box = BoxBounds(1.0, 2.0, 'abcde')
+
+        with self.assertRaises(RuntimeError):
+            box = BoxBounds('a', 2, 3.0)
+
+        with self.assertRaises(RuntimeError):
+            box = BoxBounds(1.0, 'b', 4.0)
+
+        box = BoxBounds(1,2,3)
+        box = BoxBounds(1,2,[3,5])
 
     def testCircle(self):
         myFov = SpatialBounds.getSpatialBounds('circle',1.0,2.0,1.0)


### PR DESCRIPTION
This branch rewrites ObservationMetaData to use getters and setters so that, if users try to change parameters on the fly, the spatial bounds of the field of view remain self-consistent.  Note: if users try to set parameters that were originally set by a phoSimMetaData dict on the fly, ObservationMetaData will raise an exception, since phoSimMetaData contains information specific to phoSim and it is unlikely that the user's changes will leave everything self-consistent.
