### PR TITLE
Fix typo in error statement.

### DIFF
--- a/python/lsst/sims/catalogs/generation/db/dbConnection.py
+++ b/python/lsst/sims/catalogs/generation/db/dbConnection.py
@@ -330,7 +330,7 @@ class CatalogDBObjectMeta(type):
                 pass #Don't add typeIds that are None
             elif cls.objectTypeId in cls.objectTypeIdList:
                 warnings.warn('Duplicate object type id %s specified: '%cls.objectTypeId+\
-                              '\nOutput object ids may not be unique.\nThis may not be a problem if you do not'+\
+                              '\nOutput object ids may not be unique.\nThis may not be a problem if you do not '+\
                               'want globally unique id values')
             else:
                 cls.objectTypeIdList.append(cls.objectTypeId)


### PR DESCRIPTION
There was a missing space.  This made the error string say `notwant` instead of `not want`.
