### PR TITLE
Bugfix/sim 1595/compound catalog db object

### DIFF
--- a/python/lsst/sims/catalogs/generation/db/CompoundCatalogDBObject.py
+++ b/python/lsst/sims/catalogs/generation/db/CompoundCatalogDBObject.py
@@ -41,8 +41,9 @@ class CompoundCatalogDBObject(CatalogDBObject):
 
     def __init__(self, catalogDbObjectClassList, connection=None):
         """
-        @param [in] catalogDbObjectList is a list of CatalogDBObject daughter
-        classes that all query the same database table
+        @param [in] catalogDbObjectClassList is a list of CatalogDBObject
+        daughter classes (not instantiations of those classes; the classes
+        themselves) that all query the same database table
 
         Note: this is a list of classes, not a list of instantiations of those
         classes.  The connection to the database is established as soon as

--- a/python/lsst/sims/catalogs/generation/db/CompoundCatalogDBObject.py
+++ b/python/lsst/sims/catalogs/generation/db/CompoundCatalogDBObject.py
@@ -39,7 +39,7 @@ class CompoundCatalogDBObject(CatalogDBObject):
     # _table_restriction==None, then any table is supported
     _table_restriction = None
 
-    def __init__(self, catalogDbObjectClassList):
+    def __init__(self, catalogDbObjectClassList, connection=None):
         """
         @param [in] catalogDbObjectList is a list of CatalogDBObject daughter
         classes that all query the same database table
@@ -52,6 +52,11 @@ class CompoundCatalogDBObject(CatalogDBObject):
         own connection in this constructor.  This means that all connection
         parameters must be specified in the class definitions of the classes
         passed into catalogDbObjectClassList.
+
+        @param [in] connection is an optional instantiation of DBConnection
+        representing an active connection to the database required by
+        this CompoundCatalogDBObject (prevents the CompoundCatalogDBObject
+        from opening a redundant connection)
         """
 
         self._dbObjectClassList = catalogDbObjectClassList
@@ -65,7 +70,7 @@ class CompoundCatalogDBObject(CatalogDBObject):
         self._make_dbTypeMap()
         self._make_dbDefaultValues()
 
-        dbo = self._dbObjectClassList[0]()
+        dbo = self._dbObjectClassList[0](connection=connection)
         # need to instantiate the first one because sometimes
         # idColKey is not defined until instantiation
         # (see GalaxyTileObj in sims_catUtils/../baseCatalogModels/GalaxyModels.py

--- a/python/lsst/sims/catalogs/generation/db/CompoundCatalogDBObject.py
+++ b/python/lsst/sims/catalogs/generation/db/CompoundCatalogDBObject.py
@@ -203,7 +203,7 @@ class CompoundCatalogDBObject(CatalogDBObject):
             acceptable = False
             msg += ' hosts: ' + str(hostList) + '\n'
 
-        if len(databaseList)>1:
+        if len(databaseList)!=1:
             acceptable = False
             msg += ' databases: ' + str(databaseList) + '\n'
 
@@ -215,7 +215,7 @@ class CompoundCatalogDBObject(CatalogDBObject):
             acceptable = False
             msg += ' drivers: ' + str(driverList) + '\n'
 
-        if len(tableList)>1:
+        if len(tableList)!=1:
             acceptable = False
             msg += ' tables: ' + str(tableList) + '\n'
 

--- a/python/lsst/sims/catalogs/generation/db/CompoundCatalogDBObject.py
+++ b/python/lsst/sims/catalogs/generation/db/CompoundCatalogDBObject.py
@@ -65,7 +65,11 @@ class CompoundCatalogDBObject(CatalogDBObject):
         self._make_dbTypeMap()
         self._make_dbDefaultValues()
 
-        dbo = self._dbObjectClassList[0]
+        dbo = self._dbObjectClassList[0]()
+        # need to instantiate the first one because sometimes
+        # idColKey is not defined until instantiation
+        # (see GalaxyTileObj in sims_catUtils/../baseCatalogModels/GalaxyModels.py
+
         self.tableid = dbo.tableid
         self.idColKey = dbo.idColKey
         self.raColName = dbo.raColName
@@ -91,8 +95,7 @@ class CompoundCatalogDBObject(CatalogDBObject):
         else:
             verbose = False
 
-        super(CompoundCatalogDBObject, self).__init__(database=dbo.database, driver=driver,
-                                                      host=host, port=port, verbose=verbose)
+        super(CompoundCatalogDBObject, self).__init__(connection=dbo.connection)
 
 
     def _make_columns(self):

--- a/python/lsst/sims/catalogs/generation/db/dbConnection.py
+++ b/python/lsst/sims/catalogs/generation/db/dbConnection.py
@@ -109,9 +109,13 @@ class DBConnection(object):
         self._port = port
         self._verbose = verbose
 
+        self._connect_to_engine()
+
+
+    def _connect_to_engine(self):
 
         #DbAuth will not look up hosts that are None, '' or 0
-        if host:
+        if self._host:
             try:
                 authDict = {'username': DbAuth.username(self._host, str(self._port)),
                             'password': DbAuth.password(self._host, str(self._port))}

--- a/tests/testCatalogDBObject.py
+++ b/tests/testCatalogDBObject.py
@@ -128,8 +128,8 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         if os.path.exists('testCatalogDBObjectDatabase.db'):
             print "deleting database"
             os.unlink('testCatalogDBObjectDatabase.db')
-        tu.makeStarTestDB(filename='testCatalogDBObjectDatabase.db', size=100000, seedVal=1)
-        tu.makeGalTestDB(filename='testCatalogDBObjectDatabase.db', size=100000, seedVal=1)
+        tu.makeStarTestDB(filename='testCatalogDBObjectDatabase.db', size=5000, seedVal=1)
+        tu.makeGalTestDB(filename='testCatalogDBObjectDatabase.db', size=5000, seedVal=1)
         createNonsenseDB()
 
     @classmethod

--- a/tests/testCatalogDBObject.py
+++ b/tests/testCatalogDBObject.py
@@ -83,6 +83,22 @@ class myNonsenseDB(CatalogDBObject):
                ('NonsenseDecJ2000', 'dec*%f'%(numpy.pi/180.)),
                ('NonsenseMag', 'mag', float)]
 
+class myNonsenseDB_noConnection(CatalogDBObject):
+    """
+    In order to test that we can pass a DBConnection in
+    through the constructor
+    """
+    objid = 'Nonsense_noConnection'
+    tableid = 'test'
+    idColKey = 'NonsenseId'
+    raColName = 'ra'
+    decColName = 'dec'
+    columns = [('NonsenseId', 'id', int),
+               ('NonsenseRaJ2000', 'ra*%f'%(numpy.pi/180.)),
+               ('NonsenseDecJ2000', 'dec*%f'%(numpy.pi/180.)),
+               ('NonsenseMag', 'mag', float)]
+
+
 class myNonsenseFileDB(fileDBObject):
     objid = 'fileNonsense'
     tableid = 'test'
@@ -367,6 +383,7 @@ class CatalogDBObjectTestCase(unittest.TestCase):
             self.assertEqual(row[0], row[2])
             self.assertAlmostEqual(row[1], 0.5*row[3], 6)
 
+
     def testArbitraryChunkIterator(self):
         """
         Test method to create a ChunkIterator from an arbitrary SQL query (inherited from DBObject class)
@@ -500,6 +517,243 @@ class CatalogDBObjectTestCase(unittest.TestCase):
                 self.assertEqual(line[0], controlArr[ix][0])
                 self.assertEqual(line[1], controlArr[ix][1])
                 self.assertEqual(line[2], controlArr[ix][2])
+
+
+    # The tests below all replicate tests above, except with CatalogDBObjects whose
+    # connection was passed directly in from the constructor, in order to make sure
+    # that passing a connection in works.
+
+    def testNonsenseCircularConstraints_passConnection(self):
+        """
+        Test that a query performed on a circle bound gets all of the objects (and only all
+        of the objects) within that circle.
+
+        Pass connection directly in to the constructor.
+        """
+
+        myNonsense_base = CatalogDBObject.from_objid('Nonsense')
+        myNonsense = myNonsenseDB_noConnection(connection=myNonsense_base.connection)
+
+        radius = 20.0
+        raCenter = 210.0
+        decCenter = -60.0
+
+        mycolumns = ['NonsenseId', 'NonsenseRaJ2000', 'NonsenseDecJ2000', 'NonsenseMag']
+
+        circObsMd = ObservationMetaData(boundType='circle', pointingRA=raCenter, pointingDec=decCenter,
+                                        boundLength=radius, mjd=52000., bandpassName='r')
+
+        circQuery = myNonsense.query_columns(colnames = mycolumns, obs_metadata=circObsMd, chunk_size=100)
+
+        raCenter = numpy.radians(raCenter)
+        decCenter = numpy.radians(decCenter)
+        radius = numpy.radians(radius)
+
+        goodPoints = []
+
+        for chunk in circQuery:
+            for row in chunk:
+                distance = haversine(raCenter, decCenter, row[1], row[2])
+
+                # the 0.01 degree offset is because ObservationMetaData may have had
+                # to adjust boundLength to account for the transformation from
+                # observed to ICRS coordinates
+                self.assertLess(distance, radius+numpy.radians(0.01))
+
+                dex = numpy.where(self.baselineData['id'] == row[0])[0][0]
+
+                #store a list of which objects fell within our circle bound
+                goodPoints.append(row[0])
+
+                self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
+                self.assertAlmostEqual(numpy.radians(self.baselineData['dec'][dex]), row[2], 3)
+                self.assertAlmostEqual(self.baselineData['mag'][dex], row[3], 3)
+
+
+        for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
+            #make sure that all of the points not returned by the query were, in fact, outside of
+            #the circle bound
+            distance = haversine(raCenter, decCenter, numpy.radians(entry[1]), numpy.radians(entry[2]))
+            self.assertGreater(distance, radius)
+
+
+    def testNonsenseSelectOnlySomeColumns_passConnection(self):
+        """
+        Test a query performed only a subset of the available columns
+
+        Pass connection directly in to the constructor.
+        """
+        myNonsense_base = CatalogDBObject.from_objid('Nonsense')
+        myNonsense = myNonsenseDB_noConnection(connection=myNonsense_base.connection)
+
+        mycolumns = ['NonsenseId', 'NonsenseRaJ2000', 'NonsenseMag']
+
+        query = myNonsense.query_columns(colnames=mycolumns, constraint = 'ra < 45.', chunk_size=100)
+
+        goodPoints = []
+
+        for chunk in query:
+            for row in chunk:
+                self.assertLess(row[1], 45.0)
+
+                dex = numpy.where(self.baselineData['id'] == row[0])[0][0]
+
+                goodPoints.append(row[0])
+
+                self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
+                self.assertAlmostEqual(self.baselineData['mag'][dex], row[2], 3)
+
+
+        for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
+            self.assertGreater(entry[1], 45.0)
+
+    def testNonsenseBoxConstraints_passConnection(self):
+        """
+        Test that a query performed on a box bound gets all of the points (and only all of the
+        points) inside that box bound.
+
+        Pass connection directly in to the constructor.
+        """
+
+        myNonsense_base = CatalogDBObject.from_objid('Nonsense')
+        myNonsense = myNonsenseDB_noConnection(connection=myNonsense_base.connection)
+
+        raMin = 50.0
+        raMax = 150.0
+        decMax = 30.0
+        decMin = -20.0
+
+        raCenter = 0.5*(raMin+raMax)
+        decCenter = 0.5*(decMin+decMax)
+
+        mycolumns = ['NonsenseId', 'NonsenseRaJ2000', 'NonsenseDecJ2000', 'NonsenseMag']
+
+        boxObsMd = ObservationMetaData(boundType='box', pointingDec=decCenter,  pointingRA=raCenter,
+                   boundLength=numpy.array([0.5*(raMax-raMin), 0.5*(decMax-decMin)]), mjd=52000., bandpassName='r')
+
+        boxQuery = myNonsense.query_columns(obs_metadata=boxObsMd, chunk_size=100, colnames=mycolumns)
+
+        raMin = numpy.radians(raMin)
+        raMax = numpy.radians(raMax)
+        decMin = numpy.radians(decMin)
+        decMax = numpy.radians(decMax)
+
+        goodPoints = []
+
+        for chunk in boxQuery:
+            for row in chunk:
+                self.assertLess(row[1], raMax)
+                self.assertGreater(row[1], raMin)
+                self.assertLess(row[2], decMax)
+                self.assertGreater(row[2], decMin)
+
+                dex = numpy.where(self.baselineData['id'] == row[0])[0][0]
+
+                #keep a list of which points were returned by teh query
+                goodPoints.append(row[0])
+
+                self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
+                self.assertAlmostEqual(numpy.radians(self.baselineData['dec'][dex]), row[2], 3)
+                self.assertAlmostEqual(self.baselineData['mag'][dex], row[3], 3)
+
+        for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
+            #make sure that the points not returned by the query are, in fact, outside of the
+            #box bound
+
+            switch = (entry[1] > raMax or entry[1] < raMin or entry[2] >decMax or entry[2] < decMin)
+            self.assertTrue(switch)
+
+    def testNonsenseArbitraryConstraints_passConnection(self):
+        """
+        Test a query with a user-specified constraint on the magnitude column
+
+        Pass connection directly in to the constructor.
+        """
+
+        myNonsense_base = CatalogDBObject.from_objid('Nonsense')
+        myNonsense = myNonsenseDB_noConnection(connection=myNonsense_base.connection)
+
+        raMin = 50.0
+        raMax = 150.0
+        decMax = 30.0
+        decMin = -20.0
+        raCenter=0.5*(raMin+raMax)
+        decCenter=0.5*(decMin+decMax)
+
+        mycolumns = ['NonsenseId', 'NonsenseRaJ2000', 'NonsenseDecJ2000', 'NonsenseMag']
+
+        boxObsMd = ObservationMetaData(boundType='box', pointingRA=raCenter, pointingDec=decCenter,
+                    boundLength=numpy.array([0.5*(raMax-raMin), 0.5*(decMax-decMin)]), mjd=52000., bandpassName='r')
+
+        boxQuery = myNonsense.query_columns(colnames = mycolumns,
+                      obs_metadata=boxObsMd, chunk_size=100, constraint = 'mag > 11.0')
+
+        raMin = numpy.radians(raMin)
+        raMax = numpy.radians(raMax)
+        decMin = numpy.radians(decMin)
+        decMax = numpy.radians(decMax)
+
+        goodPoints = []
+
+        for chunk in boxQuery:
+            for row in chunk:
+
+                self.assertLess(row[1], raMax)
+                self.assertGreater(row[1], raMin)
+                self.assertLess(row[2], decMax)
+                self.assertGreater(row[2], decMin)
+                self.assertGreater(row[3], 11.0)
+
+                dex = numpy.where(self.baselineData['id'] == row[0])[0][0]
+
+                #keep a list of the points returned by the query
+                goodPoints.append(row[0])
+
+                self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
+                self.assertAlmostEqual(numpy.radians(self.baselineData['dec'][dex]), row[2], 3)
+                self.assertAlmostEqual(self.baselineData['mag'][dex], row[3], 3)
+
+        for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
+            #make sure that the points not returned by the query did, in fact, violate one of the
+            #constraints of the query (either the box bound or the magnitude cut off)
+            switch = (entry[1] > raMax or entry[1] < raMin or entry[2] >decMax or entry[2] < decMin or entry[3]<11.0)
+
+            self.assertTrue(switch)
+
+    def testArbitraryQuery_passConnection(self):
+        """
+        Test method to directly execute an arbitrary SQL query (inherited from DBObject class)
+
+        Pass connection directly in to the constructor.
+        """
+        myNonsense_base = CatalogDBObject.from_objid('Nonsense')
+        myNonsense = myNonsenseDB_noConnection(connection=myNonsense_base.connection)
+        query = 'SELECT test.id, test.mag, test2.id, test2.mag FROM test, test2 WHERE test.id=test2.id'
+        results = myNonsense.execute_arbitrary(query)
+        self.assertEqual(len(results), 1250)
+        for row in results:
+            self.assertEqual(row[0], row[2])
+            self.assertAlmostEqual(row[1], 0.5*row[3], 6)
+
+
+    def testArbitraryChunkIterator_passConnection(self):
+        """
+        Test method to create a ChunkIterator from an arbitrary SQL query (inherited from DBObject class)
+
+        Pass connection directly in to the constructor.
+        """
+        myNonsense_base = CatalogDBObject.from_objid('Nonsense')
+        myNonsense = myNonsenseDB_noConnection(connection=myNonsense_base.connection)
+        query = 'SELECT test.id, test.mag, test2.id, test2.mag FROM test, test2 WHERE test.id=test2.id'
+        dtype = numpy.dtype([('id1', int), ('mag1', float), ('id2', int), ('mag2', float)])
+        results = myNonsense.get_chunk_iterator(query, chunk_size=100, dtype=dtype)
+        i = 0
+        for chunk in results:
+            for row in chunk:
+                self.assertEqual(row[0], row[2])
+                self.assertAlmostEqual(row[1], 0.5*row[3], 6)
+                i += 1
+        self.assertEqual(i, 1250)
 
 
 class fileDBObjectTestCase(unittest.TestCase):

--- a/tests/testCatalogDBObject.py
+++ b/tests/testCatalogDBObject.py
@@ -181,10 +181,14 @@ class CatalogDBObjectTestCase(unittest.TestCase):
                                         constraint = 'ra < 90. and ra > 45.')
 
         tol=1.0e-3
+        ct = 0
         for chunk in myquery:
             for star in chunk:
+                ct += 1
                 self.assertLess(numpy.degrees(star[1]), 90.0+tol)
                 self.assertGreater(numpy.degrees(star[1]), 45.0-tol)
+        self.assertGreater(ct, 0)
+
 
     def testNonsenseCircularConstraints(self):
         """
@@ -211,8 +215,10 @@ class CatalogDBObjectTestCase(unittest.TestCase):
 
         goodPoints = []
 
+        ct = 0
         for chunk in circQuery:
             for row in chunk:
+                ct += 1
                 distance = haversine(raCenter, decCenter, row[1], row[2])
 
                 # the 0.01 degree offset is because ObservationMetaData may have had
@@ -228,13 +234,16 @@ class CatalogDBObjectTestCase(unittest.TestCase):
                 self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
                 self.assertAlmostEqual(numpy.radians(self.baselineData['dec'][dex]), row[2], 3)
                 self.assertAlmostEqual(self.baselineData['mag'][dex], row[3], 3)
+        self.assertGreater(ct, 0)
 
-
+        ct = 0
         for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
             #make sure that all of the points not returned by the query were, in fact, outside of
             #the circle bound
+            ct += 1
             distance = haversine(raCenter, decCenter, numpy.radians(entry[1]), numpy.radians(entry[2]))
             self.assertGreater(distance, radius)
+        self.assertGreater(ct, 0)
 
 
     def testNonsenseSelectOnlySomeColumns(self):
@@ -249,8 +258,10 @@ class CatalogDBObjectTestCase(unittest.TestCase):
 
         goodPoints = []
 
+        ct = 0
         for chunk in query:
             for row in chunk:
+                ct += 1
                 self.assertLess(row[1], 45.0)
 
                 dex = numpy.where(self.baselineData['id'] == row[0])[0][0]
@@ -260,9 +271,14 @@ class CatalogDBObjectTestCase(unittest.TestCase):
                 self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
                 self.assertAlmostEqual(self.baselineData['mag'][dex], row[2], 3)
 
+        self.assertGreater(ct, 0)
 
+        ct = 0
         for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
             self.assertGreater(entry[1], 45.0)
+            ct += 1
+        self.assertGreater(ct, 0)
+
 
     def testNonsenseBoxConstraints(self):
         """
@@ -294,8 +310,10 @@ class CatalogDBObjectTestCase(unittest.TestCase):
 
         goodPoints = []
 
+        ct = 0
         for chunk in boxQuery:
             for row in chunk:
+                ct += 1
                 self.assertLess(row[1], raMax)
                 self.assertGreater(row[1], raMin)
                 self.assertLess(row[2], decMax)
@@ -310,12 +328,18 @@ class CatalogDBObjectTestCase(unittest.TestCase):
                 self.assertAlmostEqual(numpy.radians(self.baselineData['dec'][dex]), row[2], 3)
                 self.assertAlmostEqual(self.baselineData['mag'][dex], row[3], 3)
 
+        self.assertGreater(ct, 0)
+
+        ct = 0
         for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
             #make sure that the points not returned by the query are, in fact, outside of the
             #box bound
 
             switch = (entry[1] > raMax or entry[1] < raMin or entry[2] >decMax or entry[2] < decMin)
             self.assertTrue(switch)
+            ct += 1
+        self.assertGreater(ct, 0)
+
 
     def testNonsenseArbitraryConstraints(self):
         """
@@ -346,8 +370,10 @@ class CatalogDBObjectTestCase(unittest.TestCase):
 
         goodPoints = []
 
+        ct = 0
         for chunk in boxQuery:
             for row in chunk:
+                ct += 1
 
                 self.assertLess(row[1], raMax)
                 self.assertGreater(row[1], raMin)
@@ -364,12 +390,18 @@ class CatalogDBObjectTestCase(unittest.TestCase):
                 self.assertAlmostEqual(numpy.radians(self.baselineData['dec'][dex]), row[2], 3)
                 self.assertAlmostEqual(self.baselineData['mag'][dex], row[3], 3)
 
+        self.assertGreater(ct, 0)
+
+        ct = 0
         for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
             #make sure that the points not returned by the query did, in fact, violate one of the
             #constraints of the query (either the box bound or the magnitude cut off)
             switch = (entry[1] > raMax or entry[1] < raMin or entry[2] >decMax or entry[2] < decMin or entry[3]<11.0)
 
             self.assertTrue(switch)
+            ct += 1
+        self.assertGreater(ct, 0)
+
 
     def testArbitraryQuery(self):
         """
@@ -382,6 +414,7 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         for row in results:
             self.assertEqual(row[0], row[2])
             self.assertAlmostEqual(row[1], 0.5*row[3], 6)
+        self.assertGreater(len(results), 0)
 
 
     def testArbitraryChunkIterator(self):
@@ -409,10 +442,14 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         mycolumns = ['id', 'raJ2000', 'decJ2000', 'umag', 'gmag']
         myquery = mystars.query_columns(colnames = mycolumns, chunk_size = 1000)
 
+        ct = 0
         for chunk in myquery:
             self.assertEqual(chunk.size, 1000)
             for row in chunk:
+                ct += 1
                 self.assertEqual(len(row), 5)
+        self.assertGreater(ct, 0)
+
 
     def testClassVariables(self):
         """
@@ -512,11 +549,15 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         results = db.query_columns(colnames)
         controlArr = [(1, -1, 2), (3, 4, -2), (5, 6, 7)]
 
+        ct = 0
         for chunk in results:
             for ix, line in enumerate(chunk):
+                ct += 1
                 self.assertEqual(line[0], controlArr[ix][0])
                 self.assertEqual(line[1], controlArr[ix][1])
                 self.assertEqual(line[2], controlArr[ix][2])
+
+        self.assertGreater(ct, 0)
 
 
     # The tests below all replicate tests above, except with CatalogDBObjects whose
@@ -551,8 +592,10 @@ class CatalogDBObjectTestCase(unittest.TestCase):
 
         goodPoints = []
 
+        ct = 0
         for chunk in circQuery:
             for row in chunk:
+                ct += 1
                 distance = haversine(raCenter, decCenter, row[1], row[2])
 
                 # the 0.01 degree offset is because ObservationMetaData may have had
@@ -568,13 +611,16 @@ class CatalogDBObjectTestCase(unittest.TestCase):
                 self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
                 self.assertAlmostEqual(numpy.radians(self.baselineData['dec'][dex]), row[2], 3)
                 self.assertAlmostEqual(self.baselineData['mag'][dex], row[3], 3)
+        self.assertGreater(ct, 0)
 
-
+        ct = 0
         for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
             #make sure that all of the points not returned by the query were, in fact, outside of
             #the circle bound
             distance = haversine(raCenter, decCenter, numpy.radians(entry[1]), numpy.radians(entry[2]))
             self.assertGreater(distance, radius)
+            ct += 1
+        self.assertGreater(ct, 0)
 
 
     def testNonsenseSelectOnlySomeColumns_passConnection(self):
@@ -592,8 +638,10 @@ class CatalogDBObjectTestCase(unittest.TestCase):
 
         goodPoints = []
 
+        ct = 0
         for chunk in query:
             for row in chunk:
+                ct += 1
                 self.assertLess(row[1], 45.0)
 
                 dex = numpy.where(self.baselineData['id'] == row[0])[0][0]
@@ -603,9 +651,14 @@ class CatalogDBObjectTestCase(unittest.TestCase):
                 self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
                 self.assertAlmostEqual(self.baselineData['mag'][dex], row[2], 3)
 
+        self.assertGreater(ct, 0)
 
+        ct = 0
         for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
             self.assertGreater(entry[1], 45.0)
+            ct += 1
+        self.assertGreater(ct, 0)
+
 
     def testNonsenseBoxConstraints_passConnection(self):
         """
@@ -640,8 +693,10 @@ class CatalogDBObjectTestCase(unittest.TestCase):
 
         goodPoints = []
 
+        ct = 0
         for chunk in boxQuery:
             for row in chunk:
+                ct += 1
                 self.assertLess(row[1], raMax)
                 self.assertGreater(row[1], raMin)
                 self.assertLess(row[2], decMax)
@@ -655,13 +710,18 @@ class CatalogDBObjectTestCase(unittest.TestCase):
                 self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
                 self.assertAlmostEqual(numpy.radians(self.baselineData['dec'][dex]), row[2], 3)
                 self.assertAlmostEqual(self.baselineData['mag'][dex], row[3], 3)
+        self.assertGreater(ct, 0)
 
+        ct = 0
         for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
             #make sure that the points not returned by the query are, in fact, outside of the
             #box bound
 
             switch = (entry[1] > raMax or entry[1] < raMin or entry[2] >decMax or entry[2] < decMin)
             self.assertTrue(switch)
+            ct += 1
+        self.assertGreater(ct, 0)
+
 
     def testNonsenseArbitraryConstraints_passConnection(self):
         """
@@ -695,8 +755,10 @@ class CatalogDBObjectTestCase(unittest.TestCase):
 
         goodPoints = []
 
+        ct = 0
         for chunk in boxQuery:
             for row in chunk:
+                ct += 1
 
                 self.assertLess(row[1], raMax)
                 self.assertGreater(row[1], raMin)
@@ -712,13 +774,18 @@ class CatalogDBObjectTestCase(unittest.TestCase):
                 self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
                 self.assertAlmostEqual(numpy.radians(self.baselineData['dec'][dex]), row[2], 3)
                 self.assertAlmostEqual(self.baselineData['mag'][dex], row[3], 3)
+        self.assertGreater(ct, 0)
 
+        ct = 0
         for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
             #make sure that the points not returned by the query did, in fact, violate one of the
             #constraints of the query (either the box bound or the magnitude cut off)
             switch = (entry[1] > raMax or entry[1] < raMin or entry[2] >decMax or entry[2] < decMin or entry[3]<11.0)
 
             self.assertTrue(switch)
+            ct += 1
+        self.assertGreater(ct, 0)
+
 
     def testArbitraryQuery_passConnection(self):
         """
@@ -731,9 +798,12 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         query = 'SELECT test.id, test.mag, test2.id, test2.mag FROM test, test2 WHERE test.id=test2.id'
         results = myNonsense.execute_arbitrary(query)
         self.assertEqual(len(results), 1250)
+        ct = 0
         for row in results:
+            ct += 1
             self.assertEqual(row[0], row[2])
             self.assertAlmostEqual(row[1], 0.5*row[3], 6)
+        self.assertGreater(ct, 0)
 
 
     def testArbitraryChunkIterator_passConnection(self):
@@ -847,8 +917,10 @@ class fileDBObjectTestCase(unittest.TestCase):
 
         goodPoints = []
 
+        ct = 0
         for chunk in circQuery:
             for row in chunk:
+                ct += 1
                 distance = haversine(raCenter, decCenter, row[1], row[2])
 
                 # The 0.01 degree offset is because ObservationMetaData may have had
@@ -864,13 +936,16 @@ class fileDBObjectTestCase(unittest.TestCase):
                 self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
                 self.assertAlmostEqual(numpy.radians(self.baselineData['dec'][dex]), row[2], 3)
                 self.assertAlmostEqual(self.baselineData['mag'][dex], row[3], 3)
+        self.assertGreater(ct, 0)
 
-
+        ct = 0
         for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
             #make sure that all of the points not returned by the query were, in fact, outside of
             #the circle bound
             distance = haversine(raCenter, decCenter, numpy.radians(entry[1]), numpy.radians(entry[2]))
             self.assertGreater(distance, radius)
+            ct += 1
+        self.assertGreater(ct, 0)
 
         #make sure that the CatalogDBObject which used a header gets the same result
         headerQuery = self.myNonsenseHeader.query_columns(colnames = mycolumns, obs_metadata=circObsMd, chunk_size=100)
@@ -899,8 +974,10 @@ class fileDBObjectTestCase(unittest.TestCase):
 
         goodPoints = []
 
+        ct = 0
         for chunk in query:
             for row in chunk:
+                ct += 1
                 self.assertLess(row[1], 45.0)
 
                 dex = numpy.where(self.baselineData['id'] == row[0])[0][0]
@@ -910,8 +987,13 @@ class fileDBObjectTestCase(unittest.TestCase):
                 self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
                 self.assertAlmostEqual(self.baselineData['mag'][dex], row[2], 3)
 
+        self.assertGreater(ct, 0)
+
+        ct = 0
         for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
             self.assertGreater(entry[1], 45.0)
+            ct += 1
+        self.assertGreater(ct, 0)
 
         headerQuery = self.myNonsenseHeader.query_columns(colnames=mycolumns, constraint = 'ra < 45.', chunk_size=100)
         goodPointsHeader = []
@@ -953,8 +1035,10 @@ class fileDBObjectTestCase(unittest.TestCase):
 
         goodPoints = []
 
+        ct = 0
         for chunk in boxQuery:
             for row in chunk:
+                ct += 1
                 self.assertLess(row[1], raMax)
                 self.assertGreater(row[1], raMin)
                 self.assertLess(row[2], decMax)
@@ -968,13 +1052,17 @@ class fileDBObjectTestCase(unittest.TestCase):
                 self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
                 self.assertAlmostEqual(numpy.radians(self.baselineData['dec'][dex]), row[2], 3)
                 self.assertAlmostEqual(self.baselineData['mag'][dex], row[3], 3)
+        self.assertGreater(ct, 0)
 
+        ct = 0
         for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
             #make sure that the points not returned by the query are, in fact, outside of the
             #box bound
 
             switch = (entry[1] > raMax or entry[1] < raMin or entry[2] >decMax or entry[2] < decMin)
             self.assertTrue(switch)
+            ct += 1
+        self.assertGreater(ct, 0)
 
         headerQuery = self.myNonsenseHeader.query_columns(obs_metadata=boxObsMd, chunk_size=100, colnames=mycolumns)
         goodPointsHeader = []
@@ -1017,8 +1105,10 @@ class fileDBObjectTestCase(unittest.TestCase):
 
         goodPoints = []
 
+        ct = 0
         for chunk in boxQuery:
             for row in chunk:
+                ct += 1
 
                 self.assertLess(row[1], raMax)
                 self.assertGreater(row[1], raMin)
@@ -1034,13 +1124,17 @@ class fileDBObjectTestCase(unittest.TestCase):
                 self.assertAlmostEqual(numpy.radians(self.baselineData['ra'][dex]), row[1], 3)
                 self.assertAlmostEqual(numpy.radians(self.baselineData['dec'][dex]), row[2], 3)
                 self.assertAlmostEqual(self.baselineData['mag'][dex], row[3], 3)
+        self.assertGreater(ct, 0)
 
+        ct = 0
         for entry in [xx for xx in self.baselineData if xx[0] not in goodPoints]:
             #make sure that the points not returned by the query did, in fact, violate one of the
             #constraints of the query (either the box bound or the magnitude cut off)
             switch = (entry[1] > raMax or entry[1] < raMin or entry[2] >decMax or entry[2] < decMin or entry[3]<11.0)
 
             self.assertTrue(switch)
+            ct += 1
+        self.assertGreater(ct, 0)
 
         headerQuery = self.myNonsenseHeader.query_columns(colnames = mycolumns,
                  obs_metadata=boxObsMd, chunk_size=100, constraint='mag > 11.0')
@@ -1065,10 +1159,14 @@ class fileDBObjectTestCase(unittest.TestCase):
         mycolumns = ['NonsenseId', 'NonsenseRaJ2000', 'NonsenseDecJ2000', 'NonsenseMag']
         myquery = self.myNonsense.query_columns(colnames = mycolumns, chunk_size = 100)
 
+        ct = 0
         for chunk in myquery:
             self.assertEqual(chunk.size, 100)
             for row in chunk:
+                ct += 1
                 self.assertEqual(len(row), 4)
+        self.assertGreater(ct, 0)
+
 
 def suite():
     """Returns a suite containing all the test cases in this module."""

--- a/tests/testCatalogDBObject.py
+++ b/tests/testCatalogDBObject.py
@@ -756,6 +756,30 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         self.assertEqual(i, 1250)
 
 
+    def testPassingConnectionDifferentTables(self):
+        """
+        Test that we can pass a DBConnection between DBObjects that connect to different
+        tables on the same database
+        """
+
+        dbo1 = testCatalogDBObjectTestStars()
+        cols = ['raJ2000', 'decJ2000', 'umag']
+        results = dbo1.query_columns(cols)
+        ct = 0
+        for chunk in results:
+            for line in chunk:
+                ct += 1
+        self.assertGreater(ct, 0)
+
+        ct = 0
+        db02 = testCatalogDBObjectTestGalaxies(connection=dbo1.connection)
+        cols = ['raJ2000', 'decJ2000', 'redshift']
+        for chunk in results:
+            for line in chunk:
+                ct += 1
+        self.assertEqual(ct, 0)
+
+
 class fileDBObjectTestCase(unittest.TestCase):
     """
     This class will re-implement the tests from CatalogDBObjectTestCase,

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -170,8 +170,8 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         when you violate its API
         """
 
-        # test case where they are querying the same database, but different
-        # tables
+        # test case where they are querying the same table, but different
+        # databases
         db1 = dbClass1(database=self.otherDbName, driver='sqlite')
         db2 = dbClass2(database=self.dbName, driver='sqlite')
 
@@ -181,8 +181,8 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         self.assertTrue("['%s', '%s']" % (self.otherDbName, self.dbName) \
                         in context.exception.message)
 
-        # test case where they are querying the same table, but different
-        # databases
+        # test case where they are querying the same database, but different
+        # tables
         db1 = dbClass4(database=self.dbName, driver='sqlite')
         db2 = dbClass2(database=self.dbName, driver='sqlite')
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -486,24 +486,36 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         Test that Nones are handled correctly in the CatalogDBObject
         column mappings
         """
-        db1 = dbClass1(database=self.dbName, driver='sqlite')
-        db2 = dbClass6(database=self.dbName, driver='sqlite')
-        colNames = ['class1_aa', 'class1_bb', 'class6_a', 'class6_b']
+
+        class testDbClass20(dbClass1):
+            database = self.dbName
+            driver = 'sqlite'
+
+        class testDbClass21(dbClass6):
+            database = self.dbName
+            driver = 'sqlite'
+
+        db1 = testDbClass20()
+        db2 = testDbClass21()
+        colNames = ['%s_aa' % db1.objid, '%s_bb' % db1.objid,
+                    '%s_a' % db2.objid, '%s_b' % db2.objid]
+
         compoundDb = CompoundCatalogDBObject([db1, db2])
         results = compoundDb.query_columns(colnames=colNames)
+
         for chunk in results:
-            numpy.testing.assert_array_almost_equal(chunk['class1_aa'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db1.objid],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_equal(chunk['class1_bb'],
+            numpy.testing.assert_array_equal(chunk['%s_bb' % db1.objid],
                                              self.controlArray['d'])
 
-            numpy.testing.assert_array_almost_equal(chunk['class6_a'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_a' % db2.objid],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['class6_b'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_b' % db2.objid],
                                                     self.controlArray['b'],
                                                     decimal=6)
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -253,45 +253,59 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         Verify that CompoundCatalogDBObject returns the expected
         columns.
         """
-        db1 = dbClass1(database=self.dbName, driver='sqlite')
-        db2 = dbClass2(database=self.dbName, driver='sqlite')
-        db3 = dbClass3(database=self.dbName, driver='sqlite')
+
+        class testDbClass9(dbClass1):
+            database = self.dbName
+            driver = 'sqlite'
+
+        class testDbClass10(dbClass2):
+            database = self.dbName
+            driver = 'sqlite'
+
+        class testDbClass11(dbClass3):
+            database = self.dbName
+            driver = 'sqlite'
+
+        db1 = testDbClass9()
+        db2 = testDbClass10()
+        db3 = testDbClass11()
         dbList = [db1, db2, db3]
         compoundDb = CompoundCatalogDBObject(dbList)
 
-        colNames = ['class1_aa', 'class1_bb',
-                    'class2_aa', 'class2_bb',
-                    'class3_aa', 'class3_bb', 'class3_cc']
+        colNames = ['%s_aa' % db1.objid, '%s_bb' % db1.objid,
+                    '%s_aa' % db2.objid, '%s_bb' % db2.objid,
+                    '%s_aa' % db3.objid, '%s_bb' % db3.objid,
+                    '%s_cc' % db3.objid]
 
         results = compoundDb.query_columns(colnames=colNames)
 
         for chunk in results:
-            numpy.testing.assert_array_almost_equal(chunk['class1_aa'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db1.objid],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_equal(chunk['class1_bb'],
+            numpy.testing.assert_array_equal(chunk['%s_bb' % db1.objid],
                                              self.controlArray['d'])
 
-            numpy.testing.assert_array_almost_equal(chunk['class2_aa'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db2.objid],
                                                     2.0*self.controlArray['b'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['class2_bb'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db2.objid],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
 
-            numpy.testing.assert_array_almost_equal(chunk['class3_aa'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db3.objid],
                                                     self.controlArray['c']-3.0,
                                                     decimal=6)
 
 
-            numpy.testing.assert_array_almost_equal(chunk['class3_bb'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db3.objid],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['class3_cc'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_cc' % db3.objid],
                                                     3.0*self.controlArray['b'],
                                                     decimal=6)
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -172,8 +172,16 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
 
         # test case where they are querying the same table, but different
         # databases
-        db1 = dbClass1(database=self.otherDbName, driver='sqlite')
-        db2 = dbClass2(database=self.dbName, driver='sqlite')
+        class dummyDbClass1(dbClass1):
+            database = self.otherDbName
+            driver = 'sqlite'
+
+        class dummyDbClass2(dbClass2):
+            database = self.dbName
+            driver = 'sqlite'
+
+        db1 = dummyDbClass1()
+        db2 = dummyDbClass2()
 
         with self.assertRaises(RuntimeError) as context:
             compound = CompoundCatalogDBObject([db1, db2])
@@ -183,8 +191,17 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
 
         # test case where they are querying the same database, but different
         # tables
-        db1 = dbClass4(database=self.dbName, driver='sqlite')
-        db2 = dbClass2(database=self.dbName, driver='sqlite')
+
+        class dummyDbClass3(dbClass4):
+            database = self.dbName
+            driver = 'sqlite'
+
+        class dummyDbClass4(dbClass2):
+            database = self.dbName
+            driver = 'sqlite'
+
+        db1 = dummyDbClass3()
+        db2 = dummyDbClass4()
 
         with self.assertRaises(RuntimeError) as context:
             compound = CompoundCatalogDBObject([db1, db2])
@@ -192,17 +209,37 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         self.assertTrue("['otherTest', 'test']" in context.exception.message)
 
         # test case where the CatalogDBObjects have the same objid
-        db1 = dbClass4(database=self.dbName, driver='sqlite')
-        db2 = dbClass5(database=self.dbName, driver='sqlite')
+        class dummyDbClass5(dbClass4):
+            database = self.dbName
+            driver = 'sqlite'
+            objid = 'dummy'
+
+        class dummyDbClass6(dbClass5):
+            database = self.dbName
+            driver = 'sqlite'
+            objid = 'dummy'
+
+        db1 = dummyDbClass5()
+        db2 = dummyDbClass6()
+
         with self.assertRaises(RuntimeError) as context:
             compound = CompoundCatalogDBObject([db1, db2])
 
-        self.assertTrue("objid class4 is duplicated" in context.exception.message)
+        self.assertTrue("objid dummy is duplicated" in context.exception.message)
 
         # test case where CompoundCatalogDBObject does not support the
         # tables being queried
-        db1 = dbClass1(database=self.dbName, driver='sqlite')
-        db2 = dbClass2(database=self.dbName, driver='sqlite')
+        class dummyDbClass7(dbClass1):
+            database = self.dbName
+            driver = 'sqlite'
+
+        class dummyDbClass8(dbClass2):
+            database = self.dbName
+            driver ='sqlite'
+
+        db1 = dummyDbClass7()
+        db2 = dummyDbClass8()
+
         with self.assertRaises(RuntimeError) as context:
             compound = specificCompoundObj_otherTest([db1, db2])
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -415,52 +415,66 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         """
         Verify that CompoundCatalogDBObject handles chunk_size correctly
         """
-        db1 = dbClass1(database=self.dbName, driver='sqlite')
-        db2 = dbClass2(database=self.dbName, driver='sqlite')
-        db3 = dbClass3(database=self.dbName, driver='sqlite')
+
+        class testDbClass17(dbClass1):
+            database = self.dbName
+            driver = 'sqlite'
+
+        class testDbClass18(dbClass2):
+            database = self.dbName
+            driver = 'sqlite'
+
+        class testDbClass19(dbClass3):
+            database = self.dbName
+            driver = 'sqlite'
+
+        db1 = testDbClass17()
+        db2 = testDbClass18()
+        db3 = testDbClass19()
         dbList = [db1, db2, db3]
         compoundDb = CompoundCatalogDBObject(dbList)
 
         colNames = ['id',
-                    'class1_aa', 'class1_bb',
-                    'class2_aa', 'class2_bb',
-                    'class3_aa', 'class3_bb', 'class3_cc']
+                    '%s_aa' % db1.objid, '%s_bb' % db1.objid,
+                    '%s_aa' % db2.objid, '%s_bb' % db2.objid,
+                    '%s_aa' % db3.objid, '%s_bb' % db3.objid,
+                    '%s_cc' % db3.objid]
 
         results = compoundDb.query_columns(colnames=colNames, chunk_size=10)
 
         ct = 0
 
         for chunk in results:
-            ct += len(chunk['class1_aa'])
+            ct += len(chunk['%s_aa' % db1.objid])
             rows = chunk['id']
             self.assertTrue(len(rows)<=10)
 
-            numpy.testing.assert_array_almost_equal(chunk['class1_aa'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db1.objid],
                                                     self.controlArray['a'][rows],
                                                     decimal=6)
 
-            numpy.testing.assert_array_equal(chunk['class1_bb'],
+            numpy.testing.assert_array_equal(chunk['%s_bb' % db1.objid],
                                              self.controlArray['d'][rows])
 
-            numpy.testing.assert_array_almost_equal(chunk['class2_aa'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db2.objid],
                                                     2.0*self.controlArray['b'][rows],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['class2_bb'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db2.objid],
                                                     self.controlArray['a'][rows],
                                                     decimal=6)
 
 
-            numpy.testing.assert_array_almost_equal(chunk['class3_aa'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db3.objid],
                                                     self.controlArray['c'][rows]-3.0,
                                                     decimal=6)
 
 
-            numpy.testing.assert_array_almost_equal(chunk['class3_bb'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db3.objid],
                                                     self.controlArray['a'][rows],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['class3_cc'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_cc' % db3.objid],
                                                     3.0*self.controlArray['b'][rows],
                                                     decimal=6)
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -353,45 +353,59 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         """
         Verify that _table_restriction with multiple tables also works
         """
-        db1 = dbClass1(database=self.dbName, driver='sqlite')
-        db2 = dbClass2(database=self.dbName, driver='sqlite')
-        db3 = dbClass3(database=self.dbName, driver='sqlite')
+
+        class testDbClass14(dbClass1):
+            database = self.dbName
+            driver = 'sqlite'
+
+        class testDbClass15(dbClass2):
+            database = self.dbName
+            driver = 'sqlite'
+
+        class testDbClass16(dbClass3):
+            database = self.dbName
+            driver = 'sqlite'
+
+        db1 = testDbClass14()
+        db2 = testDbClass15()
+        db3 = testDbClass16()
         dbList = [db1, db2, db3]
         compoundDb = universalCompoundObj(dbList)
 
-        colNames = ['class1_aa', 'class1_bb',
-                    'class2_aa', 'class2_bb',
-                    'class3_aa', 'class3_bb', 'class3_cc']
+        colNames = ['%s_aa' % db1.objid, '%s_bb' % db1.objid,
+                    '%s_aa' % db2.objid, '%s_bb' % db2.objid,
+                    '%s_aa' % db3.objid, '%s_bb' % db3.objid,
+                    '%s_cc' % db3.objid]
 
         results = compoundDb.query_columns(colnames=colNames)
 
         for chunk in results:
-            numpy.testing.assert_array_almost_equal(chunk['class1_aa'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db1.objid],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_equal(chunk['class1_bb'],
+            numpy.testing.assert_array_equal(chunk['%s_bb' % db1.objid],
                                              self.controlArray['d'])
 
-            numpy.testing.assert_array_almost_equal(chunk['class2_aa'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db2.objid],
                                                     2.0*self.controlArray['b'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['class2_bb'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db2.objid],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
 
-            numpy.testing.assert_array_almost_equal(chunk['class3_aa'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db3.objid],
                                                     self.controlArray['c']-3.0,
                                                     decimal=6)
 
 
-            numpy.testing.assert_array_almost_equal(chunk['class3_bb'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db3.objid],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['class3_cc'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_cc' % db3.objid],
                                                     3.0*self.controlArray['b'],
                                                     decimal=6)
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -617,14 +617,26 @@ class CompoundWithObsMetaData(unittest.TestCase):
                                   boundLength = (80.0, 25.0),
                                   mjd=53580.0)
 
-        db1 = testStarDB1(database=self.dbName, driver='sqlite')
-        db2 = testStarDB2(database=self.dbName, driver='sqlite')
+
+        class testDbClass22(testStarDB1):
+            database = self.dbName
+            driver = 'sqlite'
+
+        class testDbClass23(testStarDB2):
+            database = self.dbName
+            driver = 'sqlite'
+
+
+        db1 = testDbClass22()
+        db2 = testDbClass23()
 
         compoundDb = CompoundCatalogDBObject([db1, db2])
 
-        colnames = ['testStar1_id',
-                    'testStar1_raJ2000', 'testStar1_decJ2000', 'testStar1_magMod',
-                    'testStar2_raJ2000', 'testStar2_decJ2000', 'testStar2_magMod']
+        colnames = ['%s_id' % db1.objid,
+                    '%s_raJ2000' % db1.objid, '%s_decJ2000' % db1.objid,
+                    '%s_magMod' % db1.objid,
+                    '%s_raJ2000' % db2.objid, '%s_decJ2000' % db2.objid,
+                    '%s_magMod' % db2.objid]
 
         results = compoundDb.query_columns(colnames=colnames,
                                            obs_metadata=obs)
@@ -634,12 +646,12 @@ class CompoundWithObsMetaData(unittest.TestCase):
             for line in chunk:
                 ix = line['id']
                 good_rows.append(ix)
-                self.assertAlmostEqual(line['testStar1_raJ2000'], self.controlArray['ra'][ix], 10)
-                self.assertAlmostEqual(line['testStar1_decJ2000'], self.controlArray['dec'][ix], 10)
-                self.assertAlmostEqual(line['testStar1_magMod'], self.controlArray['mag'][ix], 10)
-                self.assertAlmostEqual(line['testStar2_raJ2000'], 2.0*self.controlArray['ra'][ix], 10)
-                self.assertAlmostEqual(line['testStar2_decJ2000'], 2.0*self.controlArray['dec'][ix], 10)
-                self.assertAlmostEqual(line['testStar2_magMod'], 2.0*self.controlArray['mag'][ix], 10)
+                self.assertAlmostEqual(line['%s_raJ2000' % db1.objid], self.controlArray['ra'][ix], 10)
+                self.assertAlmostEqual(line['%s_decJ2000' % db1.objid], self.controlArray['dec'][ix], 10)
+                self.assertAlmostEqual(line['%s_magMod' % db1.objid], self.controlArray['mag'][ix], 10)
+                self.assertAlmostEqual(line['%s_raJ2000' % db2.objid], 2.0*self.controlArray['ra'][ix], 10)
+                self.assertAlmostEqual(line['%s_decJ2000' % db2.objid], 2.0*self.controlArray['dec'][ix], 10)
+                self.assertAlmostEqual(line['%s_magMod' % db2.objid], 2.0*self.controlArray['mag'][ix], 10)
                 self.assertTrue(self.controlArray['ra'][ix]>100.0)
                 self.assertTrue(self.controlArray['ra'][ix]<260.0)
                 self.assertTrue(self.controlArray['dec'][ix]>-25.0)

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -730,14 +730,24 @@ class CompoundWithObsMetaData(unittest.TestCase):
                                   boundLength = (80.0, 25.0),
                                   mjd=53580.0)
 
-        db1 = testStarDB1(database=self.dbName, driver='sqlite')
-        db2 = testStarDB2(database=self.dbName, driver='sqlite')
+        class testDbClass26(testStarDB1):
+            database = self.dbName
+            driver = 'sqlite'
+
+        class testDbClass27(testStarDB2):
+            database = self.dbName
+            driver = 'sqlite'
+
+        db1 = testDbClass26()
+        db2 = testDbClass27()
 
         compoundDb = CompoundCatalogDBObject([db1, db2])
 
-        colnames = ['testStar1_id',
-                    'testStar1_raJ2000', 'testStar1_decJ2000', 'testStar1_magMod',
-                    'testStar2_raJ2000', 'testStar2_decJ2000', 'testStar2_magMod']
+        colnames = ['%s_id' % db1.objid,
+                    '%s_raJ2000' % db1.objid, '%s_decJ2000' % db1.objid,
+                    '%s_magMod' % db1.objid,
+                    '%s_raJ2000' % db2.objid, '%s_decJ2000' % db2.objid,
+                    '%s_magMod' % db2.objid]
 
         results = compoundDb.query_columns(colnames=colnames,
                                            obs_metadata=obs,
@@ -748,12 +758,12 @@ class CompoundWithObsMetaData(unittest.TestCase):
             for line in chunk:
                 ix = line['id']
                 good_rows.append(ix)
-                self.assertAlmostEqual(line['testStar1_raJ2000'], self.controlArray['ra'][ix], 10)
-                self.assertAlmostEqual(line['testStar1_decJ2000'], self.controlArray['dec'][ix], 10)
-                self.assertAlmostEqual(line['testStar1_magMod'], self.controlArray['mag'][ix], 10)
-                self.assertAlmostEqual(line['testStar2_raJ2000'], 2.0*self.controlArray['ra'][ix], 10)
-                self.assertAlmostEqual(line['testStar2_decJ2000'], 2.0*self.controlArray['dec'][ix], 10)
-                self.assertAlmostEqual(line['testStar2_magMod'], 2.0*self.controlArray['mag'][ix], 10)
+                self.assertAlmostEqual(line['%s_raJ2000' % db1.objid], self.controlArray['ra'][ix], 10)
+                self.assertAlmostEqual(line['%s_decJ2000' % db1.objid], self.controlArray['dec'][ix], 10)
+                self.assertAlmostEqual(line['%s_magMod' % db1.objid], self.controlArray['mag'][ix], 10)
+                self.assertAlmostEqual(line['%s_raJ2000' % db2.objid], 2.0*self.controlArray['ra'][ix], 10)
+                self.assertAlmostEqual(line['%s_decJ2000' % db2.objid], 2.0*self.controlArray['dec'][ix], 10)
+                self.assertAlmostEqual(line['%s_magMod' % db2.objid], 2.0*self.controlArray['mag'][ix], 10)
                 self.assertTrue(self.controlArray['ra'][ix]>100.0)
                 self.assertTrue(self.controlArray['ra'][ix]<260.0)
                 self.assertTrue(self.controlArray['dec'][ix]>-25.0)

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -313,29 +313,38 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         """
         Verify that _table_restriction works the way it should in CompoundCatalogDBObject
         """
-        db1 = dbClass1(database=self.dbName, driver='sqlite')
-        db2 = dbClass2(database=self.dbName, driver='sqlite')
+
+        class testDbClass12(dbClass1):
+            database = self.dbName
+            driver = 'sqlite'
+
+        class testDbClass13(dbClass2):
+            database = self.dbName
+            driver = 'sqlite'
+
+        db1 = testDbClass12()
+        db2 = testDbClass13()
         dbList = [db1, db2]
         compoundDb = specificCompoundObj_test(dbList)
 
-        colNames = ['class1_aa', 'class1_bb',
-                    'class2_aa', 'class2_bb']
+        colNames = ['%s_aa' % db1.objid, '%s_bb' % db1.objid,
+                    '%s_aa' % db2.objid, '%s_bb' % db2.objid]
 
         results = compoundDb.query_columns(colnames=colNames)
 
         for chunk in results:
-            numpy.testing.assert_array_almost_equal(chunk['class1_aa'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db1.objid],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_equal(chunk['class1_bb'],
+            numpy.testing.assert_array_equal(chunk['%s_bb' % db1.objid],
                                              self.controlArray['d'])
 
-            numpy.testing.assert_array_almost_equal(chunk['class2_aa'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db2.objid],
                                                     2.0*self.controlArray['b'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['class2_bb'],
+            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db2.objid],
                                                     self.controlArray['a'],
                                                     decimal=6)
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -200,11 +200,8 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
             database = self.dbName
             driver = 'sqlite'
 
-        db1 = testDbClass3()
-        db2 = testDbClass4()
-
         with self.assertRaises(RuntimeError) as context:
-            compound = CompoundCatalogDBObject([db1, db2])
+            compound = CompoundCatalogDBObject([testDbClass3, testDbClass4])
 
         self.assertTrue("['otherTest', 'test']" in context.exception.message)
 
@@ -219,11 +216,8 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
             driver = 'sqlite'
             objid = 'dummy'
 
-        db1 = testDbClass5()
-        db2 = testDbClass6()
-
         with self.assertRaises(RuntimeError) as context:
-            compound = CompoundCatalogDBObject([db1, db2])
+            compound = CompoundCatalogDBObject([testDbClass5, testDbClass6])
 
         self.assertTrue("objid dummy is duplicated" in context.exception.message)
 
@@ -237,11 +231,8 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
             database = self.dbName
             driver ='sqlite'
 
-        db1 = testDbClass7()
-        db2 = testDbClass8()
-
         with self.assertRaises(RuntimeError) as context:
-            compound = specificCompoundObj_otherTest([db1, db2])
+            compound = specificCompoundObj_otherTest([testDbClass7, testDbClass8])
 
         msg = "This CompoundCatalogDBObject does not support the table 'test'"
         self.assertTrue(msg in context.exception.message)
@@ -266,9 +257,10 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
             database = self.dbName
             driver = 'sqlite'
 
-        db1 = testDbClass9()
-        db2 = testDbClass10()
-        db3 = testDbClass11()
+        db1 = testDbClass9
+        db2 = testDbClass10
+        db3 = testDbClass11
+
         dbList = [db1, db2, db3]
         compoundDb = CompoundCatalogDBObject(dbList)
 
@@ -322,8 +314,8 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
             database = self.dbName
             driver = 'sqlite'
 
-        db1 = testDbClass12()
-        db2 = testDbClass13()
+        db1 = testDbClass12
+        db2 = testDbClass13
         dbList = [db1, db2]
         compoundDb = specificCompoundObj_test(dbList)
 
@@ -366,9 +358,9 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
             database = self.dbName
             driver = 'sqlite'
 
-        db1 = testDbClass14()
-        db2 = testDbClass15()
-        db3 = testDbClass16()
+        db1 = testDbClass14
+        db2 = testDbClass15
+        db3 = testDbClass16
         dbList = [db1, db2, db3]
         compoundDb = universalCompoundObj(dbList)
 
@@ -428,9 +420,9 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
             database = self.dbName
             driver = 'sqlite'
 
-        db1 = testDbClass17()
-        db2 = testDbClass18()
-        db3 = testDbClass19()
+        db1 = testDbClass17
+        db2 = testDbClass18
+        db3 = testDbClass19
         dbList = [db1, db2, db3]
         compoundDb = CompoundCatalogDBObject(dbList)
 
@@ -495,8 +487,8 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
             database = self.dbName
             driver = 'sqlite'
 
-        db1 = testDbClass20()
-        db2 = testDbClass21()
+        db1 = testDbClass20
+        db2 = testDbClass21
         colNames = ['%s_aa' % db1.objid, '%s_bb' % db1.objid,
                     '%s_a' % db2.objid, '%s_b' % db2.objid]
 
@@ -626,9 +618,8 @@ class CompoundWithObsMetaData(unittest.TestCase):
             database = self.dbName
             driver = 'sqlite'
 
-
-        db1 = testDbClass22()
-        db2 = testDbClass23()
+        db1 = testDbClass22
+        db2 = testDbClass23
 
         compoundDb = CompoundCatalogDBObject([db1, db2])
 
@@ -681,8 +672,8 @@ class CompoundWithObsMetaData(unittest.TestCase):
             database = self.dbName
             driver = 'sqlite'
 
-        db1 = testDbClass24()
-        db2 = testDbClass25()
+        db1 = testDbClass24
+        db2 = testDbClass25
 
         compoundDb = CompoundCatalogDBObject([db1, db2])
 
@@ -738,8 +729,8 @@ class CompoundWithObsMetaData(unittest.TestCase):
             database = self.dbName
             driver = 'sqlite'
 
-        db1 = testDbClass26()
-        db2 = testDbClass27()
+        db1 = testDbClass26
+        db2 = testDbClass27
 
         compoundDb = CompoundCatalogDBObject([db1, db2])
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -672,14 +672,25 @@ class CompoundWithObsMetaData(unittest.TestCase):
         """
         Test that CompoundCatalogDBObject runs correctly with a constraint
         """
-        db1 = testStarDB1(database=self.dbName, driver='sqlite')
-        db2 = testStarDB2(database=self.dbName, driver='sqlite')
+
+        class testDbClass24(testStarDB1):
+            database = self.dbName
+            driver = 'sqlite'
+
+        class testDbClass25(testStarDB2):
+            database = self.dbName
+            driver = 'sqlite'
+
+        db1 = testDbClass24()
+        db2 = testDbClass25()
 
         compoundDb = CompoundCatalogDBObject([db1, db2])
 
-        colnames = ['testStar1_id',
-                    'testStar1_raJ2000', 'testStar1_decJ2000', 'testStar1_magMod',
-                    'testStar2_raJ2000', 'testStar2_decJ2000', 'testStar2_magMod']
+        colnames = ['%s_id' % db1.objid,
+                    '%s_raJ2000' % db1.objid, '%s_decJ2000' % db1.objid,
+                    '%s_magMod' % db1.objid,
+                    '%s_raJ2000' % db2.objid, '%s_decJ2000' % db2.objid,
+                    '%s_magMod' % db2.objid]
 
         results = compoundDb.query_columns(colnames=colnames,
                                            constraint='mag<11.0')
@@ -689,12 +700,12 @@ class CompoundWithObsMetaData(unittest.TestCase):
             for line in chunk:
                 ix = line['id']
                 good_rows.append(ix)
-                self.assertAlmostEqual(line['testStar1_raJ2000'], self.controlArray['ra'][ix], 10)
-                self.assertAlmostEqual(line['testStar1_decJ2000'], self.controlArray['dec'][ix], 10)
-                self.assertAlmostEqual(line['testStar1_magMod'], self.controlArray['mag'][ix], 10)
-                self.assertAlmostEqual(line['testStar2_raJ2000'], 2.0*self.controlArray['ra'][ix], 10)
-                self.assertAlmostEqual(line['testStar2_decJ2000'], 2.0*self.controlArray['dec'][ix], 10)
-                self.assertAlmostEqual(line['testStar2_magMod'], 2.0*self.controlArray['mag'][ix], 10)
+                self.assertAlmostEqual(line['%s_raJ2000' % db1.objid], self.controlArray['ra'][ix], 10)
+                self.assertAlmostEqual(line['%s_decJ2000' % db1.objid], self.controlArray['dec'][ix], 10)
+                self.assertAlmostEqual(line['%s_magMod' % db1.objid], self.controlArray['mag'][ix], 10)
+                self.assertAlmostEqual(line['%s_raJ2000' % db2.objid], 2.0*self.controlArray['ra'][ix], 10)
+                self.assertAlmostEqual(line['%s_decJ2000' % db2.objid], 2.0*self.controlArray['dec'][ix], 10)
+                self.assertAlmostEqual(line['%s_magMod' % db2.objid], 2.0*self.controlArray['mag'][ix], 10)
                 self.assertTrue(self.controlArray['mag'][ix]<11.0)
 
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -172,16 +172,16 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
 
         # test case where they are querying the same table, but different
         # databases
-        class dummyDbClass1(dbClass1):
+        class testDbClass1(dbClass1):
             database = self.otherDbName
             driver = 'sqlite'
 
-        class dummyDbClass2(dbClass2):
+        class testDbClass2(dbClass2):
             database = self.dbName
             driver = 'sqlite'
 
-        db1 = dummyDbClass1()
-        db2 = dummyDbClass2()
+        db1 = testDbClass1()
+        db2 = testDbClass2()
 
         with self.assertRaises(RuntimeError) as context:
             compound = CompoundCatalogDBObject([db1, db2])
@@ -192,16 +192,16 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         # test case where they are querying the same database, but different
         # tables
 
-        class dummyDbClass3(dbClass4):
+        class testDbClass3(dbClass4):
             database = self.dbName
             driver = 'sqlite'
 
-        class dummyDbClass4(dbClass2):
+        class testDbClass4(dbClass2):
             database = self.dbName
             driver = 'sqlite'
 
-        db1 = dummyDbClass3()
-        db2 = dummyDbClass4()
+        db1 = testDbClass3()
+        db2 = testDbClass4()
 
         with self.assertRaises(RuntimeError) as context:
             compound = CompoundCatalogDBObject([db1, db2])
@@ -209,18 +209,18 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         self.assertTrue("['otherTest', 'test']" in context.exception.message)
 
         # test case where the CatalogDBObjects have the same objid
-        class dummyDbClass5(dbClass4):
+        class testDbClass5(dbClass4):
             database = self.dbName
             driver = 'sqlite'
             objid = 'dummy'
 
-        class dummyDbClass6(dbClass5):
+        class testDbClass6(dbClass5):
             database = self.dbName
             driver = 'sqlite'
             objid = 'dummy'
 
-        db1 = dummyDbClass5()
-        db2 = dummyDbClass6()
+        db1 = testDbClass5()
+        db2 = testDbClass6()
 
         with self.assertRaises(RuntimeError) as context:
             compound = CompoundCatalogDBObject([db1, db2])
@@ -229,16 +229,16 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
 
         # test case where CompoundCatalogDBObject does not support the
         # tables being queried
-        class dummyDbClass7(dbClass1):
+        class testDbClass7(dbClass1):
             database = self.dbName
             driver = 'sqlite'
 
-        class dummyDbClass8(dbClass2):
+        class testDbClass8(dbClass2):
             database = self.dbName
             driver ='sqlite'
 
-        db1 = dummyDbClass7()
-        db2 = dummyDbClass8()
+        db1 = testDbClass7()
+        db2 = testDbClass8()
 
         with self.assertRaises(RuntimeError) as context:
             compound = specificCompoundObj_otherTest([db1, db2])


### PR DESCRIPTION
This addresses the problem I pointed out at the October DESC meeting, namely that CompoundCatalogDBObject was leaving open unnecessary connections to fatboy.

I have created a class DBConnection which contains all of the actual connection information for a DBObject.  Each DBObject now has an instantiation of this class.  This allows us to instantiate new DBObjects by passing in the DBConnection from old DBObjects, eliminating the need to open brand new connections to the database.

This forced a change in the API for CompoundCatalogDBObject and CompoundInstanceCatalog.  Instead of passing in instantiated InstanceCatalogs and CatalogDBObjects, we now pass in InstanceCatalog daughter classes and the CatalogDBObject daughter classes we want to associate with them.

There are supporting pull requests in

sims_catalogs_measures
sims_catUtils
sims_maf
